### PR TITLE
Implement planner-executor-critic scoring loop

### DIFF
--- a/backend/app/services/scoring_orchestrator.py
+++ b/backend/app/services/scoring_orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import time
 import uuid
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -49,6 +50,42 @@ LIFECYCLE_STEPS = (
     AGENT_STATE_REWRITE_PLAN,
 )
 
+SCORING_EXECUTOR_MAX_ATTEMPTS = 2
+SCORE_TERM_PATTERN = re.compile(r"[a-z0-9][a-z0-9+\-/]*")
+MISSING_HINT_PATTERN = re.compile(
+    r"\b(missing|lack(?:ing)?|gap(?:s)?|need(?:s|ed)?|insufficient|improve(?:ment)?|strengthen|requires?)\b",
+    re.IGNORECASE,
+)
+SCORE_KEYWORD_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "if",
+    "in",
+    "is",
+    "it",
+    "its",
+    "no",
+    "not",
+    "of",
+    "on",
+    "or",
+    "the",
+    "this",
+    "that",
+    "to",
+    "with",
+    "your",
+    "you",
+}
+
 
 @dataclass
 class OrchestratorResult:
@@ -74,6 +111,129 @@ def _coerce_dict(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}
+
+
+def _coerce_string_items(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        value = value.strip()
+        return [value] if value else []
+    return []
+
+
+def _keyword_terms(value: Any) -> set[str]:
+    return {
+        match.group(0)
+        for match in SCORE_TERM_PATTERN.finditer(_coerce_text(value).lower())
+        if match.group(0) not in SCORE_KEYWORD_STOPWORDS and len(match.group(0)) > 1
+    }
+
+
+def _has_term_overlap(reference: Any, candidate: Any) -> bool:
+    reference_terms = _keyword_terms(reference)
+    if not reference_terms:
+        return False
+    candidate_terms = _keyword_terms(candidate)
+    if not candidate_terms:
+        return False
+    return bool(reference_terms.intersection(candidate_terms))
+
+
+def _normalize_gap_analysis_claims(gap_analysis: str) -> list[str]:
+    normalized = _coerce_text(gap_analysis)
+    if not normalized:
+        return []
+
+    claims: list[str] = []
+    for sentence in re.split(r"[.!?\n]", normalized):
+        sentence = sentence.strip()
+        if not sentence or not MISSING_HINT_PATTERN.search(sentence):
+            continue
+
+        stripped_sentence = MISSING_HINT_PATTERN.sub("", sentence).strip(" -,:").strip()
+        for chunk in re.split(r"\band\b|,|;|\*", stripped_sentence, flags=re.IGNORECASE):
+            candidate = _coerce_text(chunk)
+            if not candidate or len(_keyword_terms(candidate)) < 1:
+                continue
+            if len(candidate) > 90:
+                continue
+            claims.append(candidate)
+
+    if claims:
+        return claims
+
+    fallback = [
+        _coerce_text(part)
+        for part in re.split(r"[;,\n]", normalized)
+        if _coerce_text(part) and MISSING_HINT_PATTERN.search(part)
+    ]
+    return fallback[:8]
+
+
+def _validate_scoring_output_payload(
+    score_payload: Any,
+    scoring_plan: dict[str, Any],
+) -> list[str]:
+    """Validate the raw score payload before downstream normalization."""
+    if not isinstance(score_payload, dict):
+        return ["Score payload must be a mapping."]
+
+    required_fields = (
+        "fit_score",
+        "matched_keywords",
+        "missing_keywords",
+        "gap_analysis",
+        "rewrite_suggestions",
+    )
+    missing_fields = [field for field in required_fields if field not in score_payload]
+    if missing_fields:
+        return [f"Score payload missing field: {name}" for name in missing_fields]
+
+    issues: list[str] = []
+    try:
+        int(score_payload["fit_score"])
+    except Exception:
+        issues.append("Score payload field 'fit_score' must be integer-compatible.")
+
+    if not isinstance(score_payload["matched_keywords"], list):
+        issues.append("Score payload field 'matched_keywords' must be a list.")
+    if not isinstance(score_payload["missing_keywords"], list):
+        issues.append("Score payload field 'missing_keywords' must be a list.")
+    if not isinstance(score_payload["rewrite_suggestions"], list):
+        issues.append("Score payload field 'rewrite_suggestions' must be a list.")
+    if not isinstance(score_payload["gap_analysis"], str):
+        issues.append("Score payload field 'gap_analysis' must be a string.")
+
+    missing_keywords = _coerce_string_items(score_payload.get("missing_keywords"))
+    gap_analysis = score_payload.get("gap_analysis")
+    for keyword in missing_keywords:
+        if not _has_term_overlap(gap_analysis, keyword):
+            issues.append(f"Gap analysis does not mention missing keyword '{keyword}'.")
+
+    gap_claims = _normalize_gap_analysis_claims(_coerce_text(gap_analysis))
+    for claim in gap_claims:
+        if not _has_term_overlap(" ".join(missing_keywords), claim):
+            issues.append(f"Gap-analysis claim '{claim}' is not represented in missing_keywords.")
+
+    role_signal_hypotheses = _coerce_string_items(scoring_plan.get("missing_keyword_hypotheses"))
+    for hypothesis in role_signal_hypotheses:
+        if not (
+            _has_term_overlap(gap_analysis, hypothesis)
+            or _has_term_overlap(missing_keywords, hypothesis)
+        ):
+            issues.append(f"Planned missing-signal hypothesis '{hypothesis}' is not represented in score outputs.")
+
+    return issues
+
+
+def _reconcile_scoring_plan_with_feedback(
+    scoring_plan: dict[str, Any],
+    critic_feedback: list[str],
+) -> dict[str, Any]:
+    reconciled = _coerce_dict(scoring_plan)
+    reconciled["critic_feedback"] = critic_feedback[:3]
+    return reconciled
 
 
 def _normalize_request_key(
@@ -242,9 +402,34 @@ async def _run_scoring_step(
     jd_text: str,
     role_signal_map: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    score_payload = await score_cv_against_jd(cv_text, jd_text, role_signal_map=role_signal_map)
-    if not isinstance(score_payload, dict):
-        raise ValueError("Score payload must be a mapping.")
+    scoring_plan = await _run_scoring_planner_step(
+        cv_text,
+        jd_text,
+        role_signal_map,
+    )
+    score_payload = {}
+    critic_retries = 0
+
+    last_critic_feedback: list[str] = []
+    for attempt in range(1, SCORING_EXECUTOR_MAX_ATTEMPTS + 1):
+        score_payload = await _run_scoring_execution_step(
+            cv_text=cv_text,
+            jd_text=jd_text,
+            role_signal_map=role_signal_map,
+            scoring_plan=scoring_plan,
+        )
+        critic_feedback = _run_score_critic_step(score_payload, scoring_plan)
+        if not critic_feedback:
+            break
+
+        last_critic_feedback = critic_feedback
+        if attempt >= SCORING_EXECUTOR_MAX_ATTEMPTS:
+            raise ValueError(
+                "Score payload failed critic validation: "
+                + "; ".join(critic_feedback)
+            )
+        critic_retries += 1
+        scoring_plan = _reconcile_scoring_plan_with_feedback(scoring_plan, critic_feedback)
 
     normalized = _coerce_score_payload(_coerce_dict(score_payload))
     evidence = {
@@ -252,6 +437,9 @@ async def _run_scoring_step(
         "matched_count": len(normalized["matched_keywords"]),
         "missing_count": len(normalized["missing_keywords"]),
     }
+    if critic_retries:
+        evidence["critic_retries"] = critic_retries
+        evidence["critic_feedback"] = last_critic_feedback
     return normalized, evidence
 
 
@@ -312,6 +500,61 @@ def _run_rewrite_plan_step(score_payload: dict[str, Any]) -> tuple[dict[str, Any
         "rewrite_count": len(artifact["rewrite_suggestions"]),
     }
     return artifact, evidence
+
+
+async def _run_scoring_planner_step(
+    cv_text: str,
+    jd_text: str,
+    role_signal_map: dict[str, Any],
+) -> dict[str, Any]:
+    role_signal = _coerce_dict(role_signal_map)
+    missing_hypotheses = (
+        _coerce_string_items(role_signal.get("required_skills"))
+        + _coerce_string_items(role_signal.get("secondary_skills"))
+    )
+    if not missing_hypotheses:
+        missing_hypotheses = _coerce_string_items(role_signal.get("responsibilities"))
+    if not missing_hypotheses and _coerce_text(role_signal.get("role_summary")):
+        missing_hypotheses = [_coerce_text(role_signal.get("role_summary"))]
+
+    return {
+        "score_schema_fields": [
+            "fit_score",
+            "matched_keywords",
+            "missing_keywords",
+            "gap_analysis",
+            "rewrite_suggestions",
+        ],
+        "missing_keyword_hypotheses": missing_hypotheses[:8],
+        "score_context": {
+            "role_summary": _coerce_text(role_signal.get("role_summary")),
+            "jd_hint": _coerce_text(jd_text)[:1400],
+            "cv_hint": _coerce_text(cv_text)[:1600],
+        },
+    }
+
+
+async def _run_scoring_execution_step(
+    cv_text: str,
+    jd_text: str,
+    role_signal_map: dict[str, Any],
+    scoring_plan: dict[str, Any],
+) -> Any:
+    execution_context = _coerce_dict(role_signal_map)
+    execution_context["scoring_plan"] = _coerce_dict(scoring_plan)
+    score_payload = await score_cv_against_jd(
+        cv_text=cv_text,
+        jd_text=jd_text,
+        role_signal_map=execution_context,
+    )
+    return score_payload
+
+
+def _run_score_critic_step(
+    score_payload: Any,
+    scoring_plan: dict[str, Any],
+) -> list[str]:
+    return _validate_scoring_output_payload(score_payload, scoring_plan)
 
 
 def _snapshot_result_context(db: Session, run_id: str) -> dict[str, Any]:

--- a/backend/tests/test_scoring_orchestrator.py
+++ b/backend/tests/test_scoring_orchestrator.py
@@ -499,3 +499,144 @@ def test_rescore_run_marks_job_failed_when_orchestrator_fails(monkeypatch):
     assert run.failed_count == 1
     assert run.failed_job_ids == [13]
     verify.close()
+
+
+def test_scoring_stage_critic_retries_once_and_completes(monkeypatch):
+    Session = _make_session_factory()
+    db = Session()
+    _seed_cv(db)
+
+    scoring_calls = {"count": 0}
+
+    async def fake_role_analysis(cv_text, jd_text):
+        return {"role_summary": "backend"}, {}
+
+    async def fake_evidence_scan(cv_text, jd_text, role_signal_map):
+        return {"top_responsibilities": ["Build APIs"], "top_skills": ["Python"], "experience_signals": ["5+ years"]}, {}
+
+    async def fake_scoring_plan(cv_text, jd_text, role_signal_map):
+        return {
+            "missing_keyword_hypotheses": ["kubernetes", "observability"],
+            "score_schema_fields": [
+                "fit_score",
+                "matched_keywords",
+                "missing_keywords",
+                "gap_analysis",
+                "rewrite_suggestions",
+            ],
+        }
+
+    async def fake_scoring_executor(cv_text, jd_text, role_signal_map, scoring_plan):
+        scoring_calls["count"] += 1
+        if scoring_calls["count"] == 1:
+            return {
+                "fit_score": 88,
+                "matched_keywords": ["python", "api"],
+                "missing_keywords": ["kubernetes"],
+                "gap_analysis": "Focus on API stability and deployment.",
+                "rewrite_suggestions": ["Add stronger observability notes."],
+            }
+        return {
+            "fit_score": 89,
+            "matched_keywords": ["python", "api"],
+            "missing_keywords": ["kubernetes", "observability"],
+            "gap_analysis": "Gap analysis identifies missing Kubernetes and observability skills.",
+            "rewrite_suggestions": ["Add stronger observability notes."],
+        }
+
+    async def fake_gap_audit(role_signal_map, score_payload):
+        return {"gaps_to_address": ["kubernetes", "observability"]}, {}
+
+    async def fake_action_plan(cv_text, jd_text, score_payload, role_signal_map):
+        return {"skills_to_fix_first": ["kubernetes", "observability"]}, {}
+
+    def fake_rewrite_plan(score_payload):
+        return {"rewrite_suggestions": ["Quantify delivery metrics"]}, {}
+
+    monkeypatch.setattr(orchestrator, "_run_role_analysis_step", fake_role_analysis)
+    monkeypatch.setattr(orchestrator, "_run_evidence_scan_step", fake_evidence_scan)
+    monkeypatch.setattr(orchestrator, "_run_scoring_planner_step", fake_scoring_plan)
+    monkeypatch.setattr(orchestrator, "_run_scoring_execution_step", fake_scoring_executor)
+    monkeypatch.setattr(orchestrator, "_run_gap_audit_step", fake_gap_audit)
+    monkeypatch.setattr(orchestrator, "_run_action_plan_step", fake_action_plan)
+    monkeypatch.setattr(orchestrator, "_run_rewrite_plan_step", fake_rewrite_plan)
+
+    result = asyncio.run(
+        orchestrator.execute_scoring_orchestrator(
+            db,
+            cv_id=1,
+            cv_text="Experienced backend engineer.",
+            job_title="Senior backend engineer",
+            company="Acme",
+            job_description="Build robust API services.",
+            actor="test",
+            source="api",
+            idempotency_key="critic-retry-key",
+        )
+    )
+
+    assert result.status == AGENT_STATE_COMPLETED
+    assert result.result["fit_score"] == 89
+    assert scoring_calls["count"] == 2
+
+    scoring_artifacts = [artifact for artifact in result.artifacts if artifact.step == AGENT_STATE_SCORING]
+    assert len(scoring_artifacts) == 1
+    assert scoring_artifacts[0].evidence["critic_retries"] == 1
+    assert "Gap analysis does not mention missing keyword 'kubernetes'." in scoring_artifacts[0].evidence["critic_feedback"]
+
+
+def test_scoring_stage_fails_after_critic_retry(monkeypatch):
+    Session = _make_session_factory()
+    db = Session()
+    _seed_cv(db)
+
+    scoring_calls = {"count": 0}
+
+    async def fake_role_analysis(cv_text, jd_text):
+        return {"role_summary": "backend"}, {}
+
+    async def fake_evidence_scan(cv_text, jd_text, role_signal_map):
+        return {"top_responsibilities": ["Build APIs"], "top_skills": ["Python"], "experience_signals": ["5+ years"]}, {}
+
+    async def fake_scoring_plan(cv_text, jd_text, role_signal_map):
+        return {"missing_keyword_hypotheses": ["kubernetes", "observability"]}
+
+    async def fake_scoring_executor(cv_text, jd_text, role_signal_map, scoring_plan):
+        scoring_calls["count"] += 1
+        return {
+            "fit_score": "not-a-number",
+            "matched_keywords": "python",
+            "missing_keywords": ["kubernetes"],
+            "gap_analysis": "Focus on leadership and quality.",
+            "rewrite_suggestions": ["Add stronger observability notes."],
+        }
+
+    monkeypatch.setattr(orchestrator, "_run_role_analysis_step", fake_role_analysis)
+    monkeypatch.setattr(orchestrator, "_run_evidence_scan_step", fake_evidence_scan)
+    monkeypatch.setattr(orchestrator, "_run_scoring_planner_step", fake_scoring_plan)
+    monkeypatch.setattr(orchestrator, "_run_scoring_execution_step", fake_scoring_executor)
+
+    result = asyncio.run(
+        orchestrator.execute_scoring_orchestrator(
+            db,
+            cv_id=1,
+            cv_text="Experienced backend engineer.",
+            job_title="Senior backend engineer",
+            company="Acme",
+            job_description="Build robust API services.",
+            actor="test",
+            source="api",
+            idempotency_key="critic-fail-key",
+        )
+    )
+
+    assert result.status == AGENT_STATE_FAILED
+    assert result.current_state == AGENT_STATE_SCORING
+    assert scoring_calls["count"] == 2
+    assert result.result["fit_score"] == 0
+
+    run, transitions, artifacts = orchestrator.get_run_timeline(db, result.run_id)
+    assert run is not None
+    assert run.failed_step == AGENT_STATE_SCORING
+    assert len([item for item in transitions if item.next_state == AGENT_STATE_FAILED]) == 1
+    assert len([artifact for artifact in artifacts if artifact.step == AGENT_STATE_SCORING]) == 0


### PR DESCRIPTION
## Summary
- Implemented a three-stage scoring flow inside `backend/app/services/scoring_orchestrator.py` for planning, execution, and critic validation.
- Added a bounded critic retry path (one retry) for malformed score payloads and contradiction checks between `missing_keywords` and `gap_analysis`.
- Added scoring artifact evidence fields (`critic_retries`, `critic_feedback`) for critic cycle visibility.
- Added scoring orchestrator tests covering critic retry success and retry exhaustion failure.

## Validation
- `cd backend && python -m compileall -q app tests`
- `cd backend && DATABASE_URL=sqlite:////tmp/vett-scoring-test.db python -m pytest tests/test_scoring_orchestrator.py`

## Issue link
- Closes #3
