### PR TITLE
feat: add local STT voice input for interview prep

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -63,6 +63,13 @@ class Settings(BaseSettings):
     # Local-context tooling
     local_context_environment: str = "dev"
 
+    # Local speech-to-text
+    stt_enabled: bool = True
+    stt_model_size: str = "base"
+    stt_device: str = "auto"
+    stt_compute_type: str = "int8"
+    stt_no_speech_threshold: float = 0.6
+
     model_config = ConfigDict(
         env_file=".env",
         extra="ignore",

--- a/backend/app/routers/interview_chat.py
+++ b/backend/app/routers/interview_chat.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+from time import perf_counter
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -20,8 +22,15 @@ from ..services.interview_chat_service import (
     produce_assistant_reply,
     serialize_turn,
 )
+from ..services.stt_service import (
+    SttError,
+    SttNoSpeechError,
+    SttUnavailableError,
+    transcribe_audio_bytes,
+)
 
 router = APIRouter(prefix="/interview-chat", tags=["interview-chat"])
+logger = logging.getLogger(__name__)
 
 
 class InterviewChatSessionSummary(BaseModel):
@@ -66,6 +75,11 @@ class InterviewChatEndResponse(BaseModel):
 class InterviewChatDeleteResponse(BaseModel):
     session_id: str
     status: str
+
+
+class InterviewChatTranscriptionResponse(BaseModel):
+    transcript: str
+    latency_ms: int
 
 
 def _serialize_session(db: Session, session: InterviewChatSession, include_turns: bool) -> InterviewChatSessionDetail:
@@ -284,3 +298,61 @@ def delete_interview_session(job_id: int, session_id: str, db: Session = Depends
     db.delete(session)
     db.commit()
     return InterviewChatDeleteResponse(session_id=session_id, status="deleted")
+
+
+@router.post("/jobs/{job_id}/sessions/{session_id}/transcribe", response_model=InterviewChatTranscriptionResponse)
+async def transcribe_interview_audio(
+    job_id: int,
+    session_id: str,
+    audio_file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> InterviewChatTranscriptionResponse:
+    _load_job_or_404(db, job_id)
+    session = _load_session_or_404(db, job_id, session_id)
+    if session.status != "active":
+        raise HTTPException(status_code=400, detail="Interview session is not active")
+
+    request_started = perf_counter()
+    logger.info(
+        "stt.transcription_started session_id=%s filename=%s content_type=%s",
+        session.session_id,
+        audio_file.filename or "",
+        audio_file.content_type or "",
+    )
+
+    try:
+        payload = await audio_file.read()
+        suffix = ".webm"
+        if audio_file.filename and "." in audio_file.filename:
+            suffix = f".{audio_file.filename.rsplit('.', 1)[-1]}"
+        transcript, stt_latency_ms = transcribe_audio_bytes(audio_bytes=payload, suffix=suffix, language="en")
+        total_latency_ms = int((perf_counter() - request_started) * 1000)
+        logger.info(
+            "stt.transcription_success session_id=%s transcript_len=%s stt_latency_ms=%s total_latency_ms=%s",
+            session.session_id,
+            len(transcript),
+            stt_latency_ms,
+            total_latency_ms,
+        )
+        return InterviewChatTranscriptionResponse(transcript=transcript, latency_ms=stt_latency_ms)
+    except SttNoSpeechError as exc:
+        total_latency_ms = int((perf_counter() - request_started) * 1000)
+        logger.warning(
+            "stt.transcription_no_speech session_id=%s total_latency_ms=%s error=%s",
+            session.session_id,
+            total_latency_ms,
+            str(exc),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except SttUnavailableError as exc:
+        logger.error("stt.transcription_unavailable session_id=%s error=%s", session.session_id, str(exc))
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except SttError as exc:
+        total_latency_ms = int((perf_counter() - request_started) * 1000)
+        logger.exception(
+            "stt.transcription_failed session_id=%s total_latency_ms=%s error=%s",
+            session.session_id,
+            total_latency_ms,
+            str(exc),
+        )
+        raise HTTPException(status_code=500, detail="Audio transcription failed") from exc

--- a/backend/app/services/stt_service.py
+++ b/backend/app/services/stt_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from ..config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class SttError(RuntimeError):
+    """Base STT error."""
+
+
+class SttUnavailableError(SttError):
+    """Raised when local STT runtime is unavailable."""
+
+
+class SttNoSpeechError(SttError):
+    """Raised when audio is valid but no speech is detected."""
+
+
+@lru_cache(maxsize=1)
+def _get_whisper_model() -> Any:
+    settings = get_settings()
+    if not settings.stt_enabled:
+        raise SttUnavailableError("Local STT is disabled by configuration")
+    try:
+        from faster_whisper import WhisperModel  # type: ignore
+    except ImportError as exc:
+        raise SttUnavailableError("faster-whisper is not installed on this runtime") from exc
+
+    logger.info(
+        "stt.model_loading model=%s device=%s compute_type=%s",
+        settings.stt_model_size,
+        settings.stt_device,
+        settings.stt_compute_type,
+    )
+    return WhisperModel(
+        settings.stt_model_size,
+        device=settings.stt_device,
+        compute_type=settings.stt_compute_type,
+    )
+
+
+def transcribe_audio_bytes(
+    *,
+    audio_bytes: bytes,
+    suffix: str = ".webm",
+    language: str | None = "en",
+) -> tuple[str, int]:
+    """
+    Transcribe audio bytes with local Faster-Whisper.
+
+    Returns transcript and elapsed latency_ms.
+    """
+    started_at = perf_counter()
+    if not audio_bytes:
+        raise SttNoSpeechError("No audio data was captured")
+
+    model = _get_whisper_model()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+        handle.write(audio_bytes)
+        temp_path = Path(handle.name)
+
+    try:
+        settings = get_settings()
+        segments, _ = model.transcribe(
+            str(temp_path),
+            language=language,
+            vad_filter=True,
+            no_speech_threshold=settings.stt_no_speech_threshold,
+            condition_on_previous_text=False,
+            beam_size=1,
+        )
+        transcript_parts = [segment.text.strip() for segment in segments if str(segment.text or "").strip()]
+        transcript = " ".join(transcript_parts).strip()
+        if not transcript:
+            raise SttNoSpeechError("No speech detected in recording")
+        latency_ms = int((perf_counter() - started_at) * 1000)
+        return transcript, latency_ms
+    except SttNoSpeechError:
+        raise
+    except Exception as exc:
+        raise SttError("Transcription failed") from exc
+    finally:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("stt.tempfile_cleanup_failed path=%s", temp_path)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,4 @@ apify-shared<2
 
 # Utilities
 aiofiles==25.1.0
+faster-whisper

--- a/backend/tests/test_interview_chat.py
+++ b/backend/tests/test_interview_chat.py
@@ -1,6 +1,9 @@
 import json
+from io import BytesIO
 
 import pytest
+from fastapi import UploadFile
+from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -367,3 +370,47 @@ def test_delete_interview_session_removes_transcript_rows():
     remaining_turns = db.query(InterviewChatTurn).all()
     assert remaining_session is None
     assert remaining_turns == []
+
+
+@pytest.mark.asyncio
+async def test_transcribe_interview_audio_success(monkeypatch):
+    db = _new_db_session()
+    job = Job(title="Backend Engineer", company="Acme", description="Build APIs.")
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    session = interview_chat_router.create_or_resume_interview_session(job.id, db=db).session
+
+    def _fake_transcribe(**_kwargs):
+        return "I improved API latency by 30 percent.", 210
+
+    monkeypatch.setattr(interview_chat_router, "transcribe_audio_bytes", _fake_transcribe)
+
+    audio_file = UploadFile(filename="input.webm", file=BytesIO(b"dummy-audio"))
+    result = await interview_chat_router.transcribe_interview_audio(job.id, session.session_id, audio_file=audio_file, db=db)
+
+    assert result.transcript == "I improved API latency by 30 percent."
+    assert result.latency_ms == 210
+
+
+@pytest.mark.asyncio
+async def test_transcribe_interview_audio_no_speech_maps_to_422(monkeypatch):
+    db = _new_db_session()
+    job = Job(title="Backend Engineer", company="Acme", description="Build APIs.")
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    session = interview_chat_router.create_or_resume_interview_session(job.id, db=db).session
+
+    def _fake_transcribe(**_kwargs):
+        raise interview_chat_router.SttNoSpeechError("No speech detected in recording")
+
+    monkeypatch.setattr(interview_chat_router, "transcribe_audio_bytes", _fake_transcribe)
+
+    audio_file = UploadFile(filename="input.webm", file=BytesIO(b"dummy-audio"))
+    with pytest.raises(HTTPException) as exc_info:
+        await interview_chat_router.transcribe_interview_audio(job.id, session.session_id, audio_file=audio_file, db=db)
+    assert exc_info.value.status_code == 422
+    assert "No speech detected" in str(exc_info.value.detail)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -542,6 +542,29 @@ export const deleteInterviewChatSession = async (
   return data
 }
 
+export const transcribeInterviewAudio = async (
+  jobId: number,
+  sessionId: string,
+  audioBlob: Blob,
+): Promise<{ transcript: string; latency_ms: number }> => {
+  const form = new FormData()
+  form.append('audio_file', audioBlob, 'interview-input.webm')
+  try {
+    const { data } = await api.post<{ transcript: string; latency_ms: number }>(
+      `/interview-chat/jobs/${jobId}/sessions/${sessionId}/transcribe`,
+      form,
+      { headers: { 'Content-Type': 'multipart/form-data' }, timeout: 120000 },
+    )
+    return data
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      const detail = (error.response?.data as { detail?: string } | undefined)?.detail
+      throw new Error(detail || `Transcription failed (${error.response?.status ?? 'network'})`)
+    }
+    throw error
+  }
+}
+
 // ── Jobs (Phase 2) ────────────────────────────────────────────────────────────
 
 export interface Job {

--- a/frontend/src/pages/InterviewPrep.tsx
+++ b/frontend/src/pages/InterviewPrep.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { ArrowLeft, Loader2, Play, Square, MessageCircle, Sparkles, Trash2 } from 'lucide-react'
+import { ArrowLeft, Loader2, Play, Square, MessageCircle, Sparkles, Trash2, Mic, MicOff } from 'lucide-react'
 import toast from 'react-hot-toast'
 
 import {
@@ -11,11 +11,14 @@ import {
   getJob,
   listInterviewChatSessions,
   streamInterviewChatTurn,
+  transcribeInterviewAudio,
   type InterviewChatFeedback,
   type InterviewChatSession,
   type InterviewChatSessionDetail,
   type Job,
 } from '../lib/api'
+
+type SttState = 'idle' | 'recording' | 'transcribing' | 'error'
 
 export default function InterviewPrep() {
   const { id } = useParams<{ id: string }>()
@@ -27,8 +30,20 @@ export default function InterviewPrep() {
   const [draft, setDraft] = useState('')
   const [streamingText, setStreamingText] = useState('')
   const [latestFeedback, setLatestFeedback] = useState<InterviewChatFeedback | null>(null)
+  const [sttState, setSttState] = useState<SttState>('idle')
+  const [sttError, setSttError] = useState<string | null>(null)
+  const [isRecorderSupported] = useState<boolean>(
+    globalThis.window !== undefined &&
+      typeof navigator !== 'undefined' &&
+      typeof navigator.mediaDevices?.getUserMedia === 'function' &&
+      typeof MediaRecorder !== 'undefined',
+  )
   const transcriptRef = useRef<HTMLDivElement | null>(null)
   const autoStartedRef = useRef(false)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const mediaStreamRef = useRef<MediaStream | null>(null)
+  const audioChunksRef = useRef<BlobPart[]>([])
+  const sttStartedAtRef = useRef<number | null>(null)
 
   const numericId = useMemo(() => Number(id || 0), [id])
 
@@ -93,6 +108,22 @@ export default function InterviewPrep() {
     }
   }
 
+  const logSttEvent = (event: string, extra: Record<string, unknown> = {}): void => {
+    // Lightweight client telemetry for local debugging and latency tracking.
+    // eslint-disable-next-line no-console
+    console.info('[Interview STT]', event, { ts: new Date().toISOString(), ...extra })
+  }
+
+  const describeUnknownError = (error: unknown): string => {
+    if (error instanceof Error) return error.message
+    if (typeof error === 'string') return error
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return 'Unknown error'
+    }
+  }
+
   const activeTurnCount = activeSession?.turns.length ?? 0
   const isPreparing =
     activeSession?.status === 'active' &&
@@ -148,12 +179,146 @@ export default function InterviewPrep() {
     void startOrResume()
   }, [loading, sending, job, activeSession])
 
-  const sendMessage = async (): Promise<void> => {
-    if (!draft.trim()) return
-    const value = draft.trim()
+  const sendMessageText = async (text: string): Promise<void> => {
+    if (!text.trim()) return
+    const value = text.trim()
     setDraft('')
     await streamTurn(value)
   }
+
+  const sendMessage = async (): Promise<void> => {
+    await sendMessageText(draft)
+  }
+
+  const releaseRecorder = (): void => {
+    mediaRecorderRef.current = null
+    if (mediaStreamRef.current) {
+      mediaStreamRef.current.getTracks().forEach((track) => track.stop())
+    }
+    mediaStreamRef.current = null
+    audioChunksRef.current = []
+  }
+
+  const stopRecordingAndTranscribe = async (): Promise<void> => {
+    const recorder = mediaRecorderRef.current
+    if (recorder?.state !== 'recording') return
+
+    setSttError(null)
+    setSttState('transcribing')
+    logSttEvent('stop')
+
+    const stoppedBlob = await new Promise<Blob>((resolve) => {
+      recorder.addEventListener(
+        'stop',
+        () => {
+          const blob = new Blob(audioChunksRef.current, { type: recorder.mimeType || 'audio/webm' })
+          resolve(blob)
+        },
+        { once: true },
+      )
+      recorder.stop()
+    })
+
+    releaseRecorder()
+
+    if (!stoppedBlob.size) {
+      setSttState('error')
+      setSttError('No audio detected. Please try again or type your answer.')
+      toast.error('No speech detected. You can type your answer instead.')
+      logSttEvent('no_audio_blob')
+      return
+    }
+    if (!navigator.onLine) {
+      setSttState('error')
+      setSttError('You appear offline. Please type your answer.')
+      toast.error('Offline: speech could not be transcribed. Fallback to text input.')
+      logSttEvent('offline_before_transcribe')
+      return
+    }
+    if (!activeSession) {
+      setSttState('error')
+      return
+    }
+
+    try {
+      const result = await transcribeInterviewAudio(numericId, activeSession.session_id, stoppedBlob)
+      const transcript = result.transcript.trim()
+      if (!transcript) {
+        setSttState('error')
+        setSttError('No speech recognized. Please try again or type your answer.')
+        toast.error('No speech recognized. Fallback to typing.')
+        logSttEvent('no_speech', { latency_ms: result.latency_ms })
+        return
+      }
+      setDraft(transcript)
+      logSttEvent('transcribe_success', {
+        latency_ms: result.latency_ms,
+        transcript_chars: transcript.length,
+        capture_ms: sttStartedAtRef.current ? Date.now() - sttStartedAtRef.current : null,
+      })
+      await sendMessageText(transcript)
+      setSttState('idle')
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Transcription failed'
+      setSttState('error')
+      setSttError(message)
+      toast.error(`${message}. You can still type your answer.`)
+      logSttEvent('transcribe_error', { error: message })
+    } finally {
+      sttStartedAtRef.current = null
+    }
+  }
+
+  const toggleRecording = async (): Promise<void> => {
+    if (!isRecorderSupported) {
+      setSttState('error')
+      setSttError('This browser does not support microphone recording.')
+      toast.error('Mic input is not supported in this browser')
+      return
+    }
+    if (activeSession?.status !== 'active' || sending) return
+    if (sttState === 'transcribing') return
+
+    if (sttState === 'recording') {
+      await stopRecordingAndTranscribe()
+      return
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const recorder = new MediaRecorder(stream)
+      mediaStreamRef.current = stream
+      mediaRecorderRef.current = recorder
+      audioChunksRef.current = []
+      sttStartedAtRef.current = Date.now()
+      recorder.addEventListener('dataavailable', (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data)
+        }
+      })
+      recorder.start()
+      setSttError(null)
+      setSttState('recording')
+      logSttEvent('start', { mime_type: recorder.mimeType })
+    } catch (error: unknown) {
+      const denied = error instanceof DOMException && error.name === 'NotAllowedError'
+      const message = denied ? 'Microphone permission denied. Please allow mic access.' : 'Could not start microphone recording.'
+      setSttState('error')
+      setSttError(message)
+      toast.error(`${message} You can type your answer instead.`)
+      logSttEvent('start_error', { error: describeUnknownError(error) })
+      releaseRecorder()
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current?.state === 'recording') {
+        mediaRecorderRef.current.stop()
+      }
+      releaseRecorder()
+    }
+  }, [])
 
   const endInterview = async (): Promise<void> => {
     if (!activeSession || sending) return
@@ -195,6 +360,24 @@ export default function InterviewPrep() {
         <div className="flex items-center justify-center py-16 text-sm text-text-muted">Loading interview prep…</div>
       </div>
     )
+  }
+
+  let micButtonLabel = 'Mic'
+  if (sttState === 'recording') {
+    micButtonLabel = 'Stop'
+  } else if (sttState === 'transcribing') {
+    micButtonLabel = 'Transcribing'
+  }
+  const micButtonTitle = sttState === 'recording' ? 'Stop recording' : 'Start voice input'
+  let sttStatusText = 'Voice input: unavailable in this browser. Use text input.'
+  if (sttState === 'recording') {
+    sttStatusText = 'Voice input: recording... tap Stop to transcribe.'
+  } else if (sttState === 'transcribing') {
+    sttStatusText = 'Voice input: transcribing audio...'
+  } else if (sttState === 'error' && sttError) {
+    sttStatusText = `Voice input error: ${sttError}`
+  } else if (isRecorderSupported) {
+    sttStatusText = 'Voice input: ready (fallback to text is always available).'
   }
 
   return (
@@ -412,6 +595,21 @@ export default function InterviewPrep() {
                   />
                   <button
                     type="button"
+                    onClick={() => void toggleRecording()}
+                    disabled={activeSession.status !== 'active' || sending || sttState === 'transcribing'}
+                    className={`h-10 py-1.5 px-3 text-xs rounded-lg border disabled:opacity-60 ${
+                      sttState === 'recording'
+                        ? 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100'
+                        : 'border-border bg-surface-secondary text-text-primary hover:bg-surface'
+                    }`}
+                    title={micButtonTitle}
+                    aria-label={micButtonTitle}
+                  >
+                    {sttState === 'recording' ? <MicOff className="inline w-3 h-3 mr-1" /> : <Mic className="inline w-3 h-3 mr-1" />}
+                    {micButtonLabel}
+                  </button>
+                  <button
+                    type="button"
                     onClick={() => void sendMessage()}
                     disabled={!draft.trim() || activeSession.status !== 'active' || sending}
                     className="btn-primary h-10 py-1.5 px-3 text-xs disabled:opacity-60"
@@ -419,6 +617,9 @@ export default function InterviewPrep() {
                     {sending ? <Loader2 className="inline w-3 h-3 mr-1 animate-spin" /> : <MessageCircle className="inline w-3 h-3 mr-1" />}
                     Send
                   </button>
+                </div>
+                <div className="mt-2 text-[11px] text-text-muted">
+                  {sttStatusText}
                 </div>
               </div>
                 </>


### PR DESCRIPTION
## Summary
- Add a local interview STT backend flow with a new `/interview-chat/jobs/{job_id}/sessions/{session_id}/transcribe` endpoint powered by Faster-Whisper.
- Add microphone start/stop controls and STT lifecycle states in interview UI (`idle`, `recording`, `transcribing`, `error`) and send transcribed text through the existing chat submission pipeline.
- Handle edge cases and fallback behavior for permission denied, no speech/audio, transcription failure, and offline/network constraints with user-facing messaging and text-input fallback.
- Add basic telemetry/logging for STT start/stop/success/failure and latency in both backend and frontend paths.

## Validation
- `python -m pytest backend/tests/test_interview_chat.py`
- `npm run build` (frontend)

## Test plan
- [x] Run backend interview-chat tests.
- [x] Build frontend for typecheck + production bundle.
- [x] Manual browser test: allow mic permission and verify transcript auto-sends.
- [x] Manual browser test: deny mic permission and verify fallback messaging.
- [x] Manual browser test: record silence and verify no-speech fallback.

Closes #16