### PR TITLE
feat: add study concept mind map generation and UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -587,6 +587,51 @@ def _ensure_study_card_sets_columns() -> None:
         )
 
 
+def _ensure_mind_maps_table() -> None:
+    inspector = inspect(engine)
+    table_names = set(inspector.get_table_names())
+    with engine.begin() as connection:
+        if "mind_maps" not in table_names:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE IF NOT EXISTS mind_maps (
+                      id INTEGER PRIMARY KEY,
+                      job_id INTEGER NOT NULL REFERENCES jobs(id),
+                      doc_id INTEGER NULL REFERENCES interview_knowledge_documents(id),
+                      content_hash VARCHAR(64) NOT NULL,
+                      graph_json JSON NOT NULL,
+                      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+                    """
+                )
+            )
+        connection.execute(
+            text(
+                'CREATE UNIQUE INDEX IF NOT EXISTS "uq_mind_maps_job_doc_hash" '
+                'ON "mind_maps" ("job_id", "doc_id", "content_hash");'
+            )
+        )
+        connection.execute(
+            text(
+                'CREATE INDEX IF NOT EXISTS "ix_mind_maps_job_id" '
+                'ON "mind_maps" ("job_id");'
+            )
+        )
+        connection.execute(
+            text(
+                'CREATE INDEX IF NOT EXISTS "ix_mind_maps_doc_id" '
+                'ON "mind_maps" ("doc_id");'
+            )
+        )
+        connection.execute(
+            text(
+                'CREATE INDEX IF NOT EXISTS "ix_mind_maps_content_hash" '
+                'ON "mind_maps" ("content_hash");'
+            )
+        )
+
+
 def _wait_for_database_and_init_schema(max_attempts: int = 10, base_delay_seconds: float = 1.0) -> None:
     for attempt in range(1, max_attempts + 1):
         try:
@@ -604,6 +649,7 @@ def _wait_for_database_and_init_schema(max_attempts: int = 10, base_delay_second
             _ensure_interview_chat_sessions_table()
             _ensure_interview_chat_turns_uniqueness()
             _ensure_study_card_sets_columns()
+            _ensure_mind_maps_table()
             _ensure_pgvector_index()
             logger.info("Database connected and schema initialized.")
             return

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -686,6 +686,20 @@ def _ensure_mindmap_job_tables() -> None:
         )
 
 
+def _ensure_document_and_chunk_columns() -> None:
+    inspector = inspect(engine)
+    tables = set(inspector.get_table_names())
+    with engine.begin() as connection:
+        if "interview_knowledge_documents" in tables:
+            existing = {col["name"] for col in inspector.get_columns("interview_knowledge_documents")}
+            if "file_path" not in existing:
+                connection.execute(text("ALTER TABLE interview_knowledge_documents ADD COLUMN file_path VARCHAR(512) NULL;"))
+        if "practice_questions" in tables:
+            existing = {col["name"] for col in inspector.get_columns("practice_questions")}
+            if "chunk_page" not in existing:
+                connection.execute(text("ALTER TABLE practice_questions ADD COLUMN chunk_page INTEGER NULL;"))
+
+
 def _ensure_mindmap_node_info_columns() -> None:
     inspector = inspect(engine)
     if "mind_map_node_infos" not in set(inspector.get_table_names()):
@@ -728,6 +742,7 @@ def _wait_for_database_and_init_schema(max_attempts: int = 10, base_delay_second
             _ensure_study_card_sets_columns()
             _ensure_mind_maps_table()
             _ensure_mindmap_job_tables()
+            _ensure_document_and_chunk_columns()
             _ensure_mindmap_node_info_columns()
             _ensure_pgvector_index()
             _reset_stuck_mindmap_jobs()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import OperationalError
 
 from .database import Base, SessionLocal, engine
 from .models import cv, interview_chat, practice, score, study, user_profile  # noqa: F401 - register models
+from .models.study import MindMapJob, MindMapNodeInfo  # noqa: F401 - ensure new tables are in metadata
 from .routers import cv as cv_router
 from .routers import score as score_router
 from .routers import settings as settings_router
@@ -632,6 +633,82 @@ def _ensure_mind_maps_table() -> None:
         )
 
 
+def _ensure_mindmap_job_tables() -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS mind_map_jobs (
+                  id SERIAL PRIMARY KEY,
+                  task_id VARCHAR(64) NOT NULL UNIQUE,
+                  job_id INTEGER NOT NULL REFERENCES jobs(id),
+                  doc_id INTEGER NULL REFERENCES interview_knowledge_documents(id),
+                  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+                  error TEXT NULL,
+                  graph_json JSON NOT NULL DEFAULT '{}',
+                  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+                  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                );
+                """
+            )
+        )
+        connection.execute(
+            text('CREATE INDEX IF NOT EXISTS "ix_mind_map_jobs_task_id" ON "mind_map_jobs" ("task_id");')
+        )
+        connection.execute(
+            text('CREATE INDEX IF NOT EXISTS "ix_mind_map_jobs_job_id" ON "mind_map_jobs" ("job_id");')
+        )
+        connection.execute(
+            text('CREATE INDEX IF NOT EXISTS "ix_mind_map_jobs_doc_id" ON "mind_map_jobs" ("doc_id");')
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS mind_map_node_infos (
+                  id SERIAL PRIMARY KEY,
+                  mind_map_job_id INTEGER NOT NULL REFERENCES mind_map_jobs(id) ON DELETE CASCADE,
+                  node_id VARCHAR(128) NOT NULL,
+                  encyclopedic TEXT NOT NULL,
+                  interview_prep TEXT NOT NULL,
+                  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                );
+                """
+            )
+        )
+        connection.execute(
+            text('CREATE INDEX IF NOT EXISTS "ix_mind_map_node_infos_mind_map_job_id" ON "mind_map_node_infos" ("mind_map_job_id");')
+        )
+        connection.execute(
+            text(
+                'CREATE UNIQUE INDEX IF NOT EXISTS "uq_mind_map_node_info" '
+                'ON "mind_map_node_infos" ("mind_map_job_id", "node_id");'
+            )
+        )
+
+
+def _ensure_mindmap_node_info_columns() -> None:
+    inspector = inspect(engine)
+    if "mind_map_node_infos" not in set(inspector.get_table_names()):
+        return
+    existing = {col["name"] for col in inspector.get_columns("mind_map_node_infos")}
+    with engine.begin() as connection:
+        if "sources_json" not in existing:
+            connection.execute(text("ALTER TABLE mind_map_node_infos ADD COLUMN sources_json JSON NULL;"))
+
+
+def _reset_stuck_mindmap_jobs() -> None:
+    """Reset any jobs left in 'processing' state from a previous crashed process."""
+    with engine.begin() as connection:
+        # Allow job_id to be NULL (global-docs-only generation needs no job)
+        connection.execute(text("ALTER TABLE mind_map_jobs ALTER COLUMN job_id DROP NOT NULL;"))
+        connection.execute(
+            text(
+                "UPDATE mind_map_jobs SET status = 'failed', error = 'Process restarted mid-job' "
+                "WHERE status IN ('pending', 'processing');"
+            )
+        )
+
+
 def _wait_for_database_and_init_schema(max_attempts: int = 10, base_delay_seconds: float = 1.0) -> None:
     for attempt in range(1, max_attempts + 1):
         try:
@@ -650,7 +727,10 @@ def _wait_for_database_and_init_schema(max_attempts: int = 10, base_delay_second
             _ensure_interview_chat_turns_uniqueness()
             _ensure_study_card_sets_columns()
             _ensure_mind_maps_table()
+            _ensure_mindmap_job_tables()
+            _ensure_mindmap_node_info_columns()
             _ensure_pgvector_index()
+            _reset_stuck_mindmap_jobs()
             logger.info("Database connected and schema initialized.")
             return
         except OperationalError as exc:

--- a/backend/app/models/interview.py
+++ b/backend/app/models/interview.py
@@ -24,6 +24,7 @@ class InterviewKnowledgeDocument(Base):
     embedded_chunks = Column(Integer, nullable=False, default=0, server_default="0")
     parsed_word_count = Column(Integer, nullable=False, default=0, server_default="0")
     chunk_coverage_ratio = Column(Float, nullable=False, default=0.0, server_default="0")
+    file_path = Column(String(512), nullable=True)
     created_by_user_id = Column(String(120))
     created_at = Column(DateTime(timezone=True), server_default=sql_func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=sql_func.now())

--- a/backend/app/models/practice.py
+++ b/backend/app/models/practice.py
@@ -29,6 +29,7 @@ class PracticeQuestion(Base):
     source_table = Column(String(64), index=True)
     source_id = Column(Integer, ForeignKey("interview_knowledge_documents.id"), index=True)
     source_window = Column(String(64), index=True)
+    chunk_page = Column(Integer, nullable=True)  # 1-based PDF page number
 
 
 class QuestionCompany(Base):

--- a/backend/app/models/study.py
+++ b/backend/app/models/study.py
@@ -51,6 +51,39 @@ class StudyCardSetDocument(Base):
     card_set = relationship("StudyCardSet", back_populates="selected_documents")
 
 
+class MindMapJob(Base):
+    __tablename__ = "mind_map_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    task_id = Column(String(64), nullable=False, unique=True, index=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"), index=True, nullable=True)
+    doc_id = Column(Integer, ForeignKey("interview_knowledge_documents.id"), index=True, nullable=True)
+    status = Column(String(20), nullable=False, default="pending")  # pending | processing | done | failed
+    error = Column(Text, nullable=True)
+    graph_json = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    node_infos = relationship("MindMapNodeInfo", back_populates="mind_map_job", cascade="all, delete-orphan")
+
+
+class MindMapNodeInfo(Base):
+    __tablename__ = "mind_map_node_infos"
+    __table_args__ = (
+        UniqueConstraint("mind_map_job_id", "node_id", name="uq_mind_map_node_info"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    mind_map_job_id = Column(Integer, ForeignKey("mind_map_jobs.id", ondelete="CASCADE"), index=True, nullable=False)
+    node_id = Column(String(128), nullable=False)
+    encyclopedic = Column(Text, nullable=False)
+    interview_prep = Column(Text, nullable=False)
+    sources_json = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    mind_map_job = relationship("MindMapJob", back_populates="node_infos")
+
+
 class MindMap(Base):
     __tablename__ = "mind_maps"
     __table_args__ = (

--- a/backend/app/models/study.py
+++ b/backend/app/models/study.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Column, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -49,3 +49,17 @@ class StudyCardSetDocument(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     card_set = relationship("StudyCardSet", back_populates="selected_documents")
+
+
+class MindMap(Base):
+    __tablename__ = "mind_maps"
+    __table_args__ = (
+        UniqueConstraint("job_id", "doc_id", "content_hash", name="uq_mind_maps_job_doc_hash"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"), index=True, nullable=False)
+    doc_id = Column(Integer, ForeignKey("interview_knowledge_documents.id"), index=True, nullable=True)
+    content_hash = Column(String(64), nullable=False, index=True)
+    graph_json = Column(JSON, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/routers/jobs.py
+++ b/backend/app/routers/jobs.py
@@ -29,7 +29,7 @@ from ..models.score import Job, RescoreRun, ScrapeRequest
 from ..models.interview_research import InterviewResearchSession
 from ..models.score import AGENT_STATE_COMPLETED, AGENT_STATE_FAILED
 from ..models.interview import InterviewKnowledgeDocument
-from ..services.cv_parser import parse_cv
+from ..services.cv_parser import parse_cv, parse_cv_with_pages
 from ..services.interview_docs import build_parser_signature, chunk_interview_text, chunk_integrity_stats
 
 logger = logging.getLogger(__name__)
@@ -1240,7 +1240,7 @@ async def upload_job_interview_document(
     error_message: str | None = None
     try:
         parse_start = time.perf_counter()
-        parsed_text = parse_cv(data, filename)
+        parsed_text, _page_offsets = parse_cv_with_pages(data, filename)
         logger.info(
             "Parsed job interview document job_id=%s filename=%s parsed_chars=%s duration_ms=%.1f",
             job_id,
@@ -1287,6 +1287,19 @@ async def upload_job_interview_document(
     db.add(document)
     db.commit()
     db.refresh(document)
+
+    # Persist the original file so it can be served back to the user
+    try:
+        from pathlib import Path
+        upload_dir = Path(get_settings().upload_dir)
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        file_path = upload_dir / f"doc_{document.id}{suffix}"
+        file_path.write_bytes(data)
+        document.file_path = str(file_path)
+        db.commit()
+    except Exception:
+        logger.exception("Failed to save file to disk for document id=%s", document.id)
+
     logger.info(
         "Persisted job interview document job_id=%s document_id=%s status=%s duration_ms=%.1f",
         job_id,

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from typing import Literal, Optional
 import os
@@ -22,7 +23,7 @@ from ..models.practice import (
 )
 from ..models.interview import InterviewKnowledgeDocument
 from ..services.llm import test_connection
-from ..services.cv_parser import parse_cv
+from ..services.cv_parser import parse_cv, parse_cv_with_pages
 from ..services.interview_docs import (
     build_parser_signature,
     chunk_interview_text,
@@ -524,7 +525,7 @@ async def upload_global_interview_document(
     error_message: str | None = None
     try:
         parse_start = time.perf_counter()
-        parsed_text = parse_cv(data, filename)
+        parsed_text, _page_offsets = parse_cv_with_pages(data, filename)
         logger.info(
             "Global interview document parsed filename=%s parsed_chars=%s duration_ms=%.1f",
             filename,
@@ -569,6 +570,18 @@ async def upload_global_interview_document(
     db.add(document)
     db.commit()
     db.refresh(document)
+
+    # Persist the original file so it can be served back to the user
+    try:
+        upload_dir = Path(get_settings().upload_dir)
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        file_path = upload_dir / f"doc_{document.id}{suffix}"
+        file_path.write_bytes(data)
+        document.file_path = str(file_path)
+        db.commit()
+    except Exception:
+        logger.exception("Failed to save file to disk for document id=%s", document.id)
+
     logger.info(
         "Global interview document persisted id=%s filename=%s status=%s duration_ms=%.1f",
         document.id,
@@ -577,6 +590,24 @@ async def upload_global_interview_document(
         (time.perf_counter() - start_ts) * 1000,
     )
     return _serialize_interview_document(document)
+
+
+@router.get("/interview-documents/{doc_id}/file")
+def serve_interview_document_file(
+    doc_id: int,
+    db: Annotated[Session, Depends(get_db)],
+):
+    document = db.query(InterviewKnowledgeDocument).filter(InterviewKnowledgeDocument.id == doc_id).first()
+    if document is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if not document.file_path:
+        raise HTTPException(status_code=404, detail="File not stored for this document")
+    file_path = Path(document.file_path)
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="File not found on disk")
+    suffix = file_path.suffix.lower()
+    media_type = "application/pdf" if suffix == ".pdf" else "application/octet-stream"
+    return FileResponse(str(file_path), media_type=media_type, filename=document.source_filename or file_path.name)
 
 
 @router.get("/interview-documents/progress", response_model=list[InterviewKnowledgeDocumentProgressResponse])

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -159,6 +159,8 @@ class MindMapNodeSource(BaseModel):
     index: int
     filename: str
     snippet: str
+    doc_id: int | None = None
+    page_number: int | None = None
 
 
 class MindMapNodeInfoResponse(BaseModel):

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -110,7 +110,7 @@ class ReviewRequest(BaseModel):
 
 
 class MindMapRequest(BaseModel):
-    job_id: int
+    job_id: int | None = None
     doc_id: int | None = None
 
 
@@ -140,6 +140,44 @@ class MindMapResponse(BaseModel):
     node_sources: dict[str, str] = Field(default_factory=dict)
     created_at: str | None = None
     cached: bool = False
+    task_id: str | None = None
+
+
+class MindMapJobStartResponse(BaseModel):
+    task_id: str
+    status: str
+
+
+class MindMapJobStatusResponse(BaseModel):
+    task_id: str
+    status: str
+    error: str | None = None
+    graph: MindMapGraphResponse | None = None
+
+
+class MindMapNodeSource(BaseModel):
+    index: int
+    filename: str
+    snippet: str
+
+
+class MindMapNodeInfoResponse(BaseModel):
+    node_id: str
+    encyclopedic: str
+    interview_prep: str
+    sources: list[MindMapNodeSource] = Field(default_factory=list)
+
+
+class MindMapChatRequest(BaseModel):
+    message: str = Field(min_length=1, max_length=2000)
+
+
+class MindMapChatResponse(BaseModel):
+    answer: str
+    sources: list[MindMapNodeSource] = Field(default_factory=list)
+
+
+_mindmap_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
 
 
 def _now_iso() -> str:
@@ -337,23 +375,89 @@ def review_flashcard(
     return FlashcardResponse.model_validate(flashcards.serialize_study_card(card))
 
 
-@router.post("/mindmap", response_model=MindMapResponse)
-async def create_or_get_mindmap(
+@router.post("/mindmap", response_model=MindMapJobStartResponse)
+async def start_mindmap_job(
     payload: MindMapRequest,
     db: Session = Depends(get_db),
-) -> MindMapResponse:
+) -> MindMapJobStartResponse:
+    if payload.job_id is None and payload.doc_id is None:
+        raise HTTPException(status_code=400, detail="Provide a job id, a document, or both.")
     try:
-        result, from_cache = await mindmap.generate_or_get_mind_map(
-            db,
-            job_id=payload.job_id,
-            doc_id=payload.doc_id,
-        )
+        task_id = mindmap.create_mindmap_job(db, job_id=payload.job_id, doc_id=payload.doc_id)
     except ValueError as exc:
         detail = str(exc)
-        if "not found" in detail.lower():
-            raise HTTPException(status_code=404, detail=detail)
-        raise HTTPException(status_code=400, detail=detail)
-    return MindMapResponse.model_validate({**result, "cached": from_cache})
+        raise HTTPException(status_code=404 if "not found" in detail.lower() else 400, detail=detail)
+    task = asyncio.create_task(mindmap.run_mindmap_job(task_id, job_id=payload.job_id, doc_id=payload.doc_id))
+    _mindmap_tasks.add(task)
+    task.add_done_callback(_mindmap_tasks.discard)
+    return MindMapJobStartResponse(task_id=task_id, status="pending")
+
+
+@router.get("/mindmap/latest", response_model=MindMapJobStatusResponse)
+def get_latest_mindmap_job(
+    job_id: int | None = Query(default=None, ge=1),
+    doc_id: int | None = Query(default=None, ge=1),
+    db: Session = Depends(get_db),
+) -> MindMapJobStatusResponse:
+    result = mindmap.get_latest_mindmap_job(db, job_id=job_id, doc_id=doc_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="No completed mind map job found")
+    graph: MindMapGraphResponse | None = None
+    if result.get("graph"):
+        graph = MindMapGraphResponse.model_validate(result["graph"])
+    return MindMapJobStatusResponse(
+        task_id=str(result["task_id"]),
+        status=str(result["status"]),
+        error=result.get("error"),  # type: ignore[arg-type]
+        graph=graph,
+    )
+
+
+@router.get("/mindmap/status/{task_id}", response_model=MindMapJobStatusResponse)
+def get_mindmap_job_status(task_id: str, db: Session = Depends(get_db)) -> MindMapJobStatusResponse:
+    try:
+        result = mindmap.get_mindmap_job_status(db, task_id=task_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    graph: MindMapGraphResponse | None = None
+    if result.get("graph"):
+        graph = MindMapGraphResponse.model_validate(result["graph"])
+    return MindMapJobStatusResponse(
+        task_id=str(result["task_id"]),
+        status=str(result["status"]),
+        error=result.get("error"),  # type: ignore[arg-type]
+        graph=graph,
+    )
+
+
+@router.get("/mindmap/{task_id}/node/{node_id}", response_model=MindMapNodeInfoResponse)
+async def get_node_info(task_id: str, node_id: str, db: Session = Depends(get_db)) -> MindMapNodeInfoResponse:
+    try:
+        result = await mindmap.get_or_generate_node_info(db, task_id=task_id, node_id=node_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return MindMapNodeInfoResponse(
+        node_id=node_id,
+        encyclopedic=str(result["encyclopedic"]),
+        interview_prep=str(result["interview_prep"]),
+        sources=[MindMapNodeSource.model_validate(s) for s in (result.get("sources") or [])],
+    )
+
+
+@router.post("/mindmap/{task_id}/chat", response_model=MindMapChatResponse)
+async def chat_mindmap(
+    task_id: str,
+    payload: MindMapChatRequest,
+    db: Session = Depends(get_db),
+) -> MindMapChatResponse:
+    try:
+        result = await mindmap.chat_with_mindmap(db, task_id=task_id, message=payload.message)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return MindMapChatResponse(
+        answer=str(result["answer"]),
+        sources=[MindMapNodeSource.model_validate(s) for s in (result.get("sources") or [])],
+    )
 
 
 @router.get("/mindmap", response_model=MindMapResponse)

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from ..database import SessionLocal, get_db
 from ..services import flashcards
 from ..services.flashcards import ReviewRating
+from ..services import mindmap
 
 
 router = APIRouter(prefix="/study", tags=["study"])
@@ -106,6 +107,39 @@ class StudyCardSetRenameRequest(BaseModel):
 
 class ReviewRequest(BaseModel):
     rating: ReviewRating
+
+
+class MindMapRequest(BaseModel):
+    job_id: int
+    doc_id: int | None = None
+
+
+class MindMapNodeResponse(BaseModel):
+    id: str
+    label: str
+    group: str
+
+
+class MindMapEdgeResponse(BaseModel):
+    source: str
+    target: str
+    label: str
+
+
+class MindMapGraphResponse(BaseModel):
+    nodes: list[MindMapNodeResponse]
+    edges: list[MindMapEdgeResponse]
+
+
+class MindMapResponse(BaseModel):
+    id: int
+    job_id: int
+    doc_id: int | None = None
+    content_hash: str
+    graph: MindMapGraphResponse
+    node_sources: dict[str, str] = Field(default_factory=dict)
+    created_at: str | None = None
+    cached: bool = False
 
 
 def _now_iso() -> str:
@@ -301,3 +335,42 @@ def review_flashcard(
             raise HTTPException(status_code=404, detail=detail)
         raise HTTPException(status_code=400, detail=detail)
     return FlashcardResponse.model_validate(flashcards.serialize_study_card(card))
+
+
+@router.post("/mindmap", response_model=MindMapResponse)
+async def create_or_get_mindmap(
+    payload: MindMapRequest,
+    db: Session = Depends(get_db),
+) -> MindMapResponse:
+    try:
+        result, from_cache = await mindmap.generate_or_get_mind_map(
+            db,
+            job_id=payload.job_id,
+            doc_id=payload.doc_id,
+        )
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail)
+        raise HTTPException(status_code=400, detail=detail)
+    return MindMapResponse.model_validate({**result, "cached": from_cache})
+
+
+@router.get("/mindmap", response_model=MindMapResponse)
+def get_mindmap(
+    job_id: int = Query(..., ge=1),
+    doc_id: int | None = Query(default=None, ge=1),
+    db: Session = Depends(get_db),
+) -> MindMapResponse:
+    try:
+        result = mindmap.get_cached_mind_map(
+            db,
+            job_id=job_id,
+            doc_id=doc_id,
+        )
+    except ValueError as exc:
+        detail = str(exc)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail)
+        raise HTTPException(status_code=400, detail=detail)
+    return MindMapResponse.model_validate({**result, "cached": True})

--- a/backend/app/services/cv_parser.py
+++ b/backend/app/services/cv_parser.py
@@ -29,6 +29,49 @@ _CONTINUATION_START_WORDS = {
     "which",
 }
 
+def parse_cv_with_pages(file_bytes: bytes, filename: str) -> tuple[str, list[int]]:
+    """Parse a document and return (text, page_start_word_indices).
+
+    page_start_word_indices[i] is the cumulative word offset where page i+1 begins.
+    For non-PDF files returns [0] since there are no page boundaries.
+    """
+    suffix = Path(filename).suffix.lower()
+    if suffix == ".pdf":
+        try:
+            return _parse_pdf_with_pages(file_bytes)
+        except Exception:
+            pass
+    text = parse_cv(file_bytes, filename)
+    return text, [0]
+
+
+def _parse_pdf_with_pages(data: bytes) -> tuple[str, list[int]]:
+    """Extract text per page via PyMuPDF and return cumulative word-offset boundaries."""
+    try:
+        import fitz
+    except ImportError as exc:
+        raise ImportError("PyMuPDF is not installed") from exc
+
+    page_texts: list[str] = []
+    with fitz.open(stream=data, filetype="pdf") as doc:
+        for page in doc:
+            page_texts.append(_normalise_extracted_text(page.get_text()))
+
+    page_start_word_indices: list[int] = []
+    word_count = 0
+    full_parts: list[str] = []
+    for page_text in page_texts:
+        page_start_word_indices.append(word_count)
+        word_count += len(page_text.split())
+        if page_text.strip():
+            full_parts.append(page_text)
+
+    full_text = "\n\n".join(full_parts).strip()
+    if not full_text:
+        raise ValueError("PyMuPDF produced no text")
+    return full_text, page_start_word_indices
+
+
 def parse_cv(file_bytes: bytes, filename: str) -> str:
     suffix = Path(filename).suffix.lower()
 

--- a/backend/app/services/interview_docs.py
+++ b/backend/app/services/interview_docs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import bisect
 import hashlib
 import re
 from typing import Iterable
@@ -72,6 +73,24 @@ def chunk_interview_text_meta(
         chunk_size=max(1, chunk_size),
         overlap=max(0, overlap),
     )
+
+
+def chunk_interview_text_with_pages(
+    text: str,
+    page_start_word_indices: list[int],
+    chunk_size: int = DOC_CHUNK_WORDS,
+    overlap: int = DOC_CHUNK_OVERLAP,
+) -> list[tuple[str, int]]:
+    """Return list of (chunk_text, 1-based page number) using cumulative word offsets."""
+    chunks_with_meta = _word_chunks_with_meta(
+        (text or "").strip(), chunk_size=max(1, chunk_size), overlap=max(0, overlap)
+    )
+    result: list[tuple[str, int]] = []
+    for start_word, _end_word, chunk_text in chunks_with_meta:
+        # bisect_right gives the count of page boundaries at or before start_word → 1-based page
+        page_num = bisect.bisect_right(page_start_word_indices, start_word)
+        result.append((chunk_text, max(1, page_num)))
+    return result
 
 
 def chunk_integrity_stats(

--- a/backend/app/services/mindmap.py
+++ b/backend/app/services/mindmap.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import datetime
+from typing import Any
+
+try:
+    import litellm
+except ModuleNotFoundError:  # pragma: no cover - test/runtime parity
+    litellm = None  # type: ignore[assignment]
+from sqlalchemy.orm import Session
+
+from ..models.interview import InterviewKnowledgeDocument
+from ..models.score import Job
+from ..models.study import MindMap
+from . import interview_docs, llm as llm_service
+
+logger = logging.getLogger(__name__)
+
+MAX_NODES = 20
+MAX_EDGES = 40
+MAX_CONTEXT_CHUNKS = 12
+MIN_NODE_LABEL_LENGTH = 2
+MIN_NODE_TOKEN_LENGTH = 3
+
+MINDMAP_PROMPT = """You are an interview study assistant.
+
+Extract a concise concept graph from the provided context snippets.
+Return exactly one JSON object with shape:
+{
+  "nodes": [{"id":"string","label":"string","group":"string"}],
+  "edges": [{"source":"string","target":"string","label":"string"}]
+}
+
+Rules:
+- Maximum 20 nodes.
+- Keep labels short and specific.
+- Use stable lowercase ids with underscores (example: "distributed_systems").
+- Edges must reference existing node ids.
+- Prefer clear relationship labels like "depends_on", "enables", "compares_with".
+- Return JSON only (no markdown).
+"""
+
+
+def _normalize_text(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _extract_json_payload(raw: str) -> str | None:
+    matched = llm_service._extract_first_json_object(raw)  # type: ignore[attr-defined]
+    if matched:
+        return matched
+    fallback_match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not fallback_match:
+        return None
+    return fallback_match.group(0)
+
+
+def _safe_slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", value).strip("_").lower()
+    if not slug:
+        slug = "concept"
+    return slug[:64]
+
+
+def _graph_from_payload(raw_payload: object) -> dict[str, list[dict[str, str]]]:
+    payload = raw_payload if isinstance(raw_payload, dict) else {}
+    raw_nodes = payload.get("nodes")
+    raw_edges = payload.get("edges")
+
+    nodes: list[dict[str, str]] = []
+    node_by_id: dict[str, dict[str, str]] = {}
+    seen_node_ids: set[str] = set()
+    for item in raw_nodes if isinstance(raw_nodes, list) else []:
+        if not isinstance(item, dict):
+            continue
+        label = _normalize_text(item.get("label"))
+        if len(label) < MIN_NODE_LABEL_LENGTH:
+            continue
+        node_id_candidate = _normalize_text(item.get("id")) or _safe_slug(label)
+        node_id = _safe_slug(node_id_candidate)
+        if node_id in seen_node_ids:
+            continue
+        node = {
+            "id": node_id,
+            "label": label[:120],
+            "group": _normalize_text(item.get("group"))[:80] or "general",
+        }
+        seen_node_ids.add(node_id)
+        node_by_id[node_id] = node
+        nodes.append(node)
+        if len(nodes) >= MAX_NODES:
+            break
+
+    edges: list[dict[str, str]] = []
+    seen_edges: set[tuple[str, str, str]] = set()
+    for item in raw_edges if isinstance(raw_edges, list) else []:
+        if not isinstance(item, dict):
+            continue
+        source = _safe_slug(_normalize_text(item.get("source")))
+        target = _safe_slug(_normalize_text(item.get("target")))
+        if source not in node_by_id or target not in node_by_id or source == target:
+            continue
+        label = _normalize_text(item.get("label"))[:80] or "related_to"
+        key = (source, target, label.lower())
+        if key in seen_edges:
+            continue
+        seen_edges.add(key)
+        edges.append(
+            {
+                "source": source,
+                "target": target,
+                "label": label,
+            }
+        )
+        if len(edges) >= MAX_EDGES:
+            break
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def _build_context_block(contexts: list[dict[str, str]]) -> str:
+    rendered: list[str] = []
+    for index, context in enumerate(contexts, start=1):
+        filename = _normalize_text(context.get("filename")) or f"document-{index}"
+        snippet = _normalize_text(context.get("snippet")) or "No snippet available."
+        rendered.append(f"{index}. {filename}: {snippet}")
+    return "\n".join(rendered)
+
+
+def _choose_source_chunks(graph: dict[str, list[dict[str, str]]], contexts: list[dict[str, str]]) -> dict[str, str]:
+    if not contexts:
+        return {}
+    context_snippets = [ctx.get("snippet", "") for ctx in contexts]
+    output: dict[str, str] = {}
+    for node in graph.get("nodes", []):
+        node_id = _normalize_text(node.get("id"))
+        label = _normalize_text(node.get("label"))
+        if not node_id or not label:
+            continue
+        tokens = [token for token in re.findall(r"[a-zA-Z0-9]+", label.lower()) if len(token) >= MIN_NODE_TOKEN_LENGTH]
+        matched = ""
+        for snippet in context_snippets:
+            snippet_lower = snippet.lower()
+            if any(token in snippet_lower for token in tokens):
+                matched = snippet
+                break
+        output[node_id] = matched or context_snippets[0]
+    return output
+
+
+async def _generate_graph_from_contexts(contexts: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    if litellm is None:
+        import litellm as runtime_litellm
+
+        completion_client = runtime_litellm
+    else:
+        completion_client = litellm
+
+    model, kwargs = llm_service._get_litellm_model()  # type: ignore[attr-defined]
+    prompt = "\n\n".join(
+        [
+            MINDMAP_PROMPT,
+            "context_snippets:",
+            _build_context_block(contexts),
+        ]
+    )
+    response = await completion_client.acompletion(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+        max_tokens=4096,
+        **kwargs,
+    )
+    content = response.choices[0].message.content or ""
+    logger.debug("MINDMAP RAW RESPONSE: %r", content[:500])
+
+    payload_text = _extract_json_payload(content) or ""
+    if not payload_text.strip():
+        return {"nodes": [], "edges": []}
+
+    try:
+        parsed = json.loads(payload_text)
+    except Exception:
+        try:
+            parsed = json.loads(llm_service._sanitize_json_token_stream(payload_text))  # type: ignore[attr-defined]
+        except Exception:
+            parsed = {}
+    return _graph_from_payload(parsed)
+
+
+def _eligible_job_documents(db: Session, *, job_id: int, doc_id: int | None) -> list[InterviewKnowledgeDocument]:
+    if doc_id is not None:
+        docs = (
+            db.query(InterviewKnowledgeDocument)
+            .filter(InterviewKnowledgeDocument.id == int(doc_id))
+            .all()
+        )
+        return docs
+
+    # Scope to global + job-specific documents as retrieval corpus for the selected job.
+    return (
+        db.query(InterviewKnowledgeDocument)
+        .filter(
+            InterviewKnowledgeDocument.status != "failed",
+            InterviewKnowledgeDocument.parsed_text.isnot(None),
+            InterviewKnowledgeDocument.parsed_text != "",
+            (
+                (InterviewKnowledgeDocument.owner_type == "global")
+                | (
+                    (InterviewKnowledgeDocument.owner_type == "job")
+                    & (InterviewKnowledgeDocument.job_id == int(job_id))
+                )
+            ),
+        )
+        .order_by(InterviewKnowledgeDocument.id.desc())
+        .all()
+    )
+
+
+def _collect_contexts_for_hash(db: Session, *, job: Job, doc_id: int | None) -> tuple[list[dict[str, str]], str]:
+    selected_docs = _eligible_job_documents(db, job_id=int(job.id), doc_id=doc_id)
+    if not selected_docs:
+        raise ValueError("No interview documents available for this selection.")
+
+    contexts: list[dict[str, str]] = []
+    if doc_id is not None:
+        document = selected_docs[0]
+        for index, snippet in enumerate(interview_docs.chunk_interview_text(document.parsed_text)):
+            contexts.append(
+                {
+                    "filename": document.source_filename,
+                    "snippet": snippet,
+                    "chunk_id": f"{document.id}:chunk:{index}",
+                }
+            )
+            if len(contexts) >= MAX_CONTEXT_CHUNKS:
+                break
+    else:
+        # Pragmatic top-k approximation across job corpus: take early chunks from newest documents.
+        for document in selected_docs:
+            for index, snippet in enumerate(interview_docs.chunk_interview_text(document.parsed_text)[:2]):
+                contexts.append(
+                    {
+                        "filename": document.source_filename,
+                        "snippet": snippet,
+                        "chunk_id": f"{document.id}:chunk:{index}",
+                    }
+                )
+                if len(contexts) >= MAX_CONTEXT_CHUNKS:
+                    break
+            if len(contexts) >= MAX_CONTEXT_CHUNKS:
+                break
+
+    if not contexts:
+        raise ValueError("No interview document content available for mind map extraction.")
+
+    hash_source = "\n".join(
+        [
+            f"job:{job.id}",
+            f"doc:{doc_id if doc_id is not None else 'all'}",
+            *[f"{ctx['chunk_id']}::{ctx['snippet']}" for ctx in contexts],
+        ]
+    )
+    content_hash = hashlib.sha256(hash_source.encode("utf-8", errors="replace")).hexdigest()
+    return contexts, content_hash
+
+
+def _serialize_payload(
+    row: MindMap,
+    *,
+    graph: dict[str, list[dict[str, str]]],
+    node_sources: dict[str, str],
+) -> dict[str, object]:
+    return {
+        "id": int(row.id),
+        "job_id": int(row.job_id),
+        "doc_id": int(row.doc_id) if row.doc_id is not None else None,
+        "content_hash": row.content_hash,
+        "graph": graph,
+        "node_sources": node_sources,
+        "created_at": row.created_at.isoformat() if isinstance(row.created_at, datetime) else None,
+    }
+
+
+async def generate_or_get_mind_map(
+    db: Session,
+    *,
+    job_id: int,
+    doc_id: int | None = None,
+) -> tuple[dict[str, object], bool]:
+    job = db.query(Job).filter(Job.id == int(job_id)).first()
+    if not job:
+        raise ValueError("Job not found")
+
+    contexts, content_hash = _collect_contexts_for_hash(db, job=job, doc_id=doc_id)
+    cached = (
+        db.query(MindMap)
+        .filter(
+            MindMap.job_id == int(job_id),
+            MindMap.doc_id == (int(doc_id) if doc_id is not None else None),
+            MindMap.content_hash == content_hash,
+        )
+        .order_by(MindMap.id.desc())
+        .first()
+    )
+    if cached:
+        graph = _graph_from_payload(cached.graph_json)
+        node_sources = _choose_source_chunks(graph, contexts)
+        return _serialize_payload(cached, graph=graph, node_sources=node_sources), True
+
+    graph = await _generate_graph_from_contexts(contexts)
+    if not graph["nodes"]:
+        raise ValueError("Mind map generation returned no concepts.")
+
+    row = MindMap(
+        job_id=int(job_id),
+        doc_id=int(doc_id) if doc_id is not None else None,
+        content_hash=content_hash,
+        graph_json=graph,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    node_sources = _choose_source_chunks(graph, contexts)
+    return _serialize_payload(row, graph=graph, node_sources=node_sources), False
+
+
+def get_cached_mind_map(
+    db: Session,
+    *,
+    job_id: int,
+    doc_id: int | None = None,
+) -> dict[str, object]:
+    job = db.query(Job).filter(Job.id == int(job_id)).first()
+    if not job:
+        raise ValueError("Job not found")
+    contexts, content_hash = _collect_contexts_for_hash(db, job=job, doc_id=doc_id)
+    cached = (
+        db.query(MindMap)
+        .filter(
+            MindMap.job_id == int(job_id),
+            MindMap.doc_id == (int(doc_id) if doc_id is not None else None),
+            MindMap.content_hash == content_hash,
+        )
+        .order_by(MindMap.id.desc())
+        .first()
+    )
+    if not cached:
+        raise ValueError("Mind map not found for current document content.")
+    graph = _graph_from_payload(cached.graph_json)
+    node_sources = _choose_source_chunks(graph, contexts)
+    return _serialize_payload(cached, graph=graph, node_sources=node_sources)

--- a/backend/app/services/mindmap.py
+++ b/backend/app/services/mindmap.py
@@ -4,43 +4,53 @@ import hashlib
 import json
 import logging
 import re
-from datetime import datetime
+import uuid
+from datetime import datetime, timezone
 from typing import Any
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 try:
     import litellm
 except ModuleNotFoundError:  # pragma: no cover - test/runtime parity
     litellm = None  # type: ignore[assignment]
-from sqlalchemy.orm import Session
 
+from ..database import SessionLocal
 from ..models.interview import InterviewKnowledgeDocument
 from ..models.score import Job
-from ..models.study import MindMap
+from ..models.study import MindMap, MindMapJob, MindMapNodeInfo
 from . import interview_docs, llm as llm_service
 
 logger = logging.getLogger(__name__)
 
-MAX_NODES = 20
-MAX_EDGES = 40
+MAX_NODES = 40
+MAX_EDGES = 80
 MAX_CONTEXT_CHUNKS = 12
+BATCH_SIZE = 10
 MIN_NODE_LABEL_LENGTH = 2
 MIN_NODE_TOKEN_LENGTH = 3
 
-MINDMAP_PROMPT = """You are an interview study assistant.
+MINDMAP_PROMPT = """You are an interview study assistant building a hierarchical mind map.
 
-Extract a concise concept graph from the provided context snippets.
+Extract a concept graph from the provided context snippets.
 Return exactly one JSON object with shape:
 {
   "nodes": [{"id":"string","label":"string","group":"string"}],
   "edges": [{"source":"string","target":"string","label":"string"}]
 }
 
-Rules:
-- Maximum 20 nodes.
-- Keep labels short and specific.
+Structure rules (CRITICAL):
+- The FIRST node must be the central root topic — the single overarching theme of the content.
+  Give it id "root" and group "root".
+- Then create 3–6 main category nodes (group "main"), each connected FROM root with an edge.
+- Each main category should have 2–4 specific subtopic/detail nodes (group "detail") branching from it.
+- Every non-root node must have at least one incoming edge from its parent.
+- Do NOT create cycles or edges that skip levels (root→detail is allowed only if no suitable main exists).
+- Maximum 15 nodes total (1 root + 4–5 main + remaining as detail).
+- Keep labels short (2–5 words).
 - Use stable lowercase ids with underscores (example: "distributed_systems").
-- Edges must reference existing node ids.
-- Prefer clear relationship labels like "depends_on", "enables", "compares_with".
+- Prefer relationship labels like "covers", "includes", "requires", "leads_to".
 - Return JSON only (no markdown).
 """
 
@@ -137,6 +147,7 @@ def _choose_source_chunks(graph: dict[str, list[dict[str, str]]], contexts: list
     if not contexts:
         return {}
     context_snippets = [ctx.get("snippet", "") for ctx in contexts]
+    lowered_snippets = [s.lower() for s in context_snippets]
     output: dict[str, str] = {}
     for node in graph.get("nodes", []):
         node_id = _normalize_text(node.get("id"))
@@ -145,8 +156,7 @@ def _choose_source_chunks(graph: dict[str, list[dict[str, str]]], contexts: list
             continue
         tokens = [token for token in re.findall(r"[a-zA-Z0-9]+", label.lower()) if len(token) >= MIN_NODE_TOKEN_LENGTH]
         matched = ""
-        for snippet in context_snippets:
-            snippet_lower = snippet.lower()
+        for snippet, snippet_lower in zip(context_snippets, lowered_snippets):
             if any(token in snippet_lower for token in tokens):
                 matched = snippet
                 break
@@ -194,7 +204,7 @@ async def _generate_graph_from_contexts(contexts: list[dict[str, str]]) -> dict[
     return _graph_from_payload(parsed)
 
 
-def _eligible_job_documents(db: Session, *, job_id: int, doc_id: int | None) -> list[InterviewKnowledgeDocument]:
+def _eligible_job_documents(db: Session, *, job_id: int | None, doc_id: int | None) -> list[InterviewKnowledgeDocument]:
     if doc_id is not None:
         docs = (
             db.query(InterviewKnowledgeDocument)
@@ -203,21 +213,28 @@ def _eligible_job_documents(db: Session, *, job_id: int, doc_id: int | None) -> 
         )
         return docs
 
-    # Scope to global + job-specific documents as retrieval corpus for the selected job.
+    base_filter = [
+        InterviewKnowledgeDocument.status != "failed",
+        InterviewKnowledgeDocument.parsed_text.isnot(None),
+        InterviewKnowledgeDocument.parsed_text != "",
+    ]
+
+    if job_id is not None:
+        # Global docs + job-specific docs
+        scope_filter = (
+            (InterviewKnowledgeDocument.owner_type == "global")
+            | (
+                (InterviewKnowledgeDocument.owner_type == "job")
+                & (InterviewKnowledgeDocument.job_id == int(job_id))
+            )
+        )
+    else:
+        # Global docs only
+        scope_filter = (InterviewKnowledgeDocument.owner_type == "global")
+
     return (
         db.query(InterviewKnowledgeDocument)
-        .filter(
-            InterviewKnowledgeDocument.status != "failed",
-            InterviewKnowledgeDocument.parsed_text.isnot(None),
-            InterviewKnowledgeDocument.parsed_text != "",
-            (
-                (InterviewKnowledgeDocument.owner_type == "global")
-                | (
-                    (InterviewKnowledgeDocument.owner_type == "job")
-                    & (InterviewKnowledgeDocument.job_id == int(job_id))
-                )
-            ),
-        )
+        .filter(*base_filter, scope_filter)
         .order_by(InterviewKnowledgeDocument.id.desc())
         .all()
     )
@@ -311,23 +328,43 @@ async def generate_or_get_mind_map(
     )
     if cached:
         graph = _graph_from_payload(cached.graph_json)
-        node_sources = _choose_source_chunks(graph, contexts)
+        node_sources = cached.graph_json.get("node_sources", {}) if isinstance(cached.graph_json, dict) else {}
         return _serialize_payload(cached, graph=graph, node_sources=node_sources), True
 
     graph = await _generate_graph_from_contexts(contexts)
     if not graph["nodes"]:
         raise ValueError("Mind map generation returned no concepts.")
 
+    node_sources = _choose_source_chunks(graph, contexts)
+    stored_json = {**graph, "node_sources": node_sources}
     row = MindMap(
         job_id=int(job_id),
         doc_id=int(doc_id) if doc_id is not None else None,
         content_hash=content_hash,
-        graph_json=graph,
+        graph_json=stored_json,
     )
     db.add(row)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        # Another concurrent request already inserted the same (job_id, doc_id, content_hash).
+        row = (
+            db.query(MindMap)
+            .filter(
+                MindMap.job_id == int(job_id),
+                MindMap.doc_id == (int(doc_id) if doc_id is not None else None),
+                MindMap.content_hash == content_hash,
+            )
+            .order_by(MindMap.id.desc())
+            .first()
+        )
+        if not row:
+            raise ValueError("Mind map could not be saved.")
+        graph = _graph_from_payload(row.graph_json)
+        node_sources = row.graph_json.get("node_sources", {}) if isinstance(row.graph_json, dict) else {}
+        return _serialize_payload(row, graph=graph, node_sources=node_sources), True
     db.refresh(row)
-    node_sources = _choose_source_chunks(graph, contexts)
     return _serialize_payload(row, graph=graph, node_sources=node_sources), False
 
 
@@ -337,16 +374,13 @@ def get_cached_mind_map(
     job_id: int,
     doc_id: int | None = None,
 ) -> dict[str, object]:
-    job = db.query(Job).filter(Job.id == int(job_id)).first()
-    if not job:
+    if not db.query(Job).filter(Job.id == int(job_id)).first():
         raise ValueError("Job not found")
-    contexts, content_hash = _collect_contexts_for_hash(db, job=job, doc_id=doc_id)
     cached = (
         db.query(MindMap)
         .filter(
             MindMap.job_id == int(job_id),
             MindMap.doc_id == (int(doc_id) if doc_id is not None else None),
-            MindMap.content_hash == content_hash,
         )
         .order_by(MindMap.id.desc())
         .first()
@@ -354,5 +388,430 @@ def get_cached_mind_map(
     if not cached:
         raise ValueError("Mind map not found for current document content.")
     graph = _graph_from_payload(cached.graph_json)
-    node_sources = _choose_source_chunks(graph, contexts)
-    return _serialize_payload(cached, graph=graph, node_sources=node_sources)
+    node_sources = cached.graph_json.get("node_sources", {}) if isinstance(cached.graph_json, dict) else {}
+    payload = _serialize_payload(cached, graph=graph, node_sources=node_sources)
+    # Look up the latest completed MindMapJob so the frontend can restore task_id for chat
+    latest_job = (
+        db.query(MindMapJob)
+        .filter(
+            MindMapJob.job_id == int(job_id),
+            MindMapJob.doc_id == (int(doc_id) if doc_id is not None else None),
+            MindMapJob.status == "done",
+        )
+        .order_by(MindMapJob.id.desc())
+        .first()
+    )
+    payload["task_id"] = latest_job.task_id if latest_job else None
+    return payload
+
+
+# ── New async job-based mind map functions ────────────────────────────────────
+
+
+def _collect_all_contexts(db: Session, *, job_id: int, doc_id: int | None) -> list[dict[str, str]]:
+    selected_docs = _eligible_job_documents(db, job_id=job_id, doc_id=doc_id)
+    if not selected_docs:
+        raise ValueError("No interview documents available for this selection.")
+    contexts: list[dict[str, str]] = []
+    if doc_id is not None:
+        document = selected_docs[0]
+        for index, snippet in enumerate(interview_docs.chunk_interview_text(document.parsed_text)):
+            contexts.append({"filename": document.source_filename, "snippet": snippet, "chunk_id": f"{document.id}:chunk:{index}"})
+    else:
+        for document in selected_docs:
+            for index, snippet in enumerate(interview_docs.chunk_interview_text(document.parsed_text)):
+                contexts.append({"filename": document.source_filename, "snippet": snippet, "chunk_id": f"{document.id}:chunk:{index}"})
+    if not contexts:
+        raise ValueError("No interview document content available for mind map extraction.")
+    return contexts
+
+
+def _merge_partial_graphs(partial_graphs: list[dict[str, list[dict[str, str]]]]) -> dict[str, list[dict[str, str]]]:
+    seen_node_ids: set[str] = set()
+    merged_nodes: list[dict[str, str]] = []
+    for graph in partial_graphs:
+        for node in graph.get("nodes", []):
+            node_id = _normalize_text(node.get("id"))
+            if not node_id or node_id in seen_node_ids:
+                continue
+            seen_node_ids.add(node_id)
+            merged_nodes.append(node)
+            if len(merged_nodes) >= MAX_NODES:
+                break
+        if len(merged_nodes) >= MAX_NODES:
+            break
+
+    seen_edges: set[tuple[str, str, str]] = set()
+    merged_edges: list[dict[str, str]] = []
+    for graph in partial_graphs:
+        for edge in graph.get("edges", []):
+            source = _normalize_text(edge.get("source"))
+            target = _normalize_text(edge.get("target"))
+            label = _normalize_text(edge.get("label"))
+            if not source or not target:
+                continue
+            key = (source, target, label.lower())
+            if key in seen_edges:
+                continue
+            seen_edges.add(key)
+            merged_edges.append(edge)
+            if len(merged_edges) >= MAX_EDGES:
+                break
+        if len(merged_edges) >= MAX_EDGES:
+            break
+
+    # Re-filter edges to only reference surviving node ids
+    surviving_ids = {node["id"] for node in merged_nodes}
+    merged_edges = [
+        edge for edge in merged_edges
+        if edge.get("source") in surviving_ids and edge.get("target") in surviving_ids
+    ]
+
+    return {"nodes": merged_nodes, "edges": merged_edges}
+
+
+async def _run_merge_pass(merged_graph: dict[str, list[dict[str, str]]]) -> list[dict[str, str]]:
+    if litellm is None:
+        import litellm as runtime_litellm
+        completion_client = runtime_litellm
+    else:
+        completion_client = litellm
+
+    model, kwargs = llm_service._get_litellm_model()  # type: ignore[attr-defined]
+    nodes_list = [{"id": node["id"], "label": node.get("label", "")} for node in merged_graph.get("nodes", [])]
+    existing_edges = merged_graph.get("edges", [])
+
+    prompt = "\n\n".join([
+        "You are given a list of concept nodes extracted from a document.",
+        "Identify important relationships BETWEEN nodes that are not already captured.",
+        'Return exactly one JSON object: {"edges": [{"source": "node_id", "target": "node_id", "label": "relationship"}]}',
+        "Only return edges. Do not add new nodes. Node ids must be from the provided list.",
+        "Return JSON only.",
+        f"nodes: {json.dumps(nodes_list)}",
+        f"existing_edges: {json.dumps(existing_edges)}",
+    ])
+
+    response = await completion_client.acompletion(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+        max_tokens=2048,
+        **kwargs,
+    )
+    content = response.choices[0].message.content or ""
+    payload_text = _extract_json_payload(content) or ""
+    if not payload_text.strip():
+        return []
+    try:
+        parsed = json.loads(payload_text)
+    except Exception:
+        try:
+            parsed = json.loads(llm_service._sanitize_json_token_stream(payload_text))  # type: ignore[attr-defined]
+        except Exception:
+            return []
+    if not isinstance(parsed, dict):
+        return []
+    raw_edges = parsed.get("edges")
+    if not isinstance(raw_edges, list):
+        return []
+    return [edge for edge in raw_edges if isinstance(edge, dict)]
+
+
+async def run_mindmap_job(task_id: str, *, job_id: int | None, doc_id: int | None) -> None:
+    db = SessionLocal()
+    try:
+        row = db.query(MindMapJob).filter(MindMapJob.task_id == task_id).first()
+        if row is None:
+            logger.error("run_mindmap_job: task_id=%s not found in DB", task_id)
+            return
+        row.status = "processing"
+        row.updated_at = datetime.now(timezone.utc)
+        db.commit()
+
+        contexts = _collect_all_contexts(db, job_id=job_id, doc_id=doc_id)
+
+        # Split into batches
+        batches: list[list[dict[str, str]]] = []
+        for start in range(0, len(contexts), BATCH_SIZE):
+            batches.append(contexts[start:start + BATCH_SIZE])
+
+        partial_graphs: list[dict[str, list[dict[str, str]]]] = []
+        merged_graph: dict[str, list[dict[str, str]]] = {"nodes": [], "edges": []}
+        for batch_contexts in batches:
+            batch_graph = await _generate_graph_from_contexts(batch_contexts)
+            partial_graphs.append(batch_graph)
+            merged_graph = _merge_partial_graphs(partial_graphs)
+            row.graph_json = merged_graph
+            row.updated_at = datetime.now(timezone.utc)
+            db.commit()
+
+        # Merge pass for cross-batch edges
+        additional_edges = await _run_merge_pass(merged_graph)
+        if additional_edges:
+            merged_graph = _merge_partial_graphs([merged_graph, {"nodes": [], "edges": additional_edges}])
+
+        row.status = "done"
+        row.graph_json = merged_graph
+        row.updated_at = datetime.now(timezone.utc)
+        db.commit()
+    except Exception as exc:
+        logger.exception("run_mindmap_job failed for task_id=%s: %s", task_id, exc)
+        try:
+            row = db.query(MindMapJob).filter(MindMapJob.task_id == task_id).first()
+            if row is not None:
+                row.status = "failed"
+                row.error = str(exc)
+                row.updated_at = datetime.now(timezone.utc)
+                db.commit()
+        except Exception:
+            logger.exception("run_mindmap_job: could not persist failure for task_id=%s", task_id)
+    finally:
+        db.close()
+
+
+def create_mindmap_job(db: Session, *, job_id: int | None, doc_id: int | None) -> str:
+    if job_id is not None and not db.query(Job).filter(Job.id == int(job_id)).first():
+        raise ValueError("Job not found")
+    task_id = str(uuid.uuid4())
+    row = MindMapJob(
+        task_id=task_id,
+        job_id=int(job_id) if job_id is not None else None,
+        doc_id=int(doc_id) if doc_id is not None else None,
+        status="pending",
+        graph_json={},
+    )
+    db.add(row)
+    db.commit()
+    return task_id
+
+
+def get_latest_mindmap_job(db: Session, *, job_id: int | None, doc_id: int | None) -> dict[str, object] | None:
+    """Return the most recent completed MindMapJob matching the given filters."""
+    query = db.query(MindMapJob).filter(MindMapJob.status == "done")
+    if job_id is not None:
+        query = query.filter(MindMapJob.job_id == int(job_id))
+    if doc_id is not None:
+        query = query.filter(MindMapJob.doc_id == int(doc_id))
+    row = query.order_by(MindMapJob.id.desc()).first()
+    if row is None:
+        return None
+    graph: dict | None = None
+    if isinstance(row.graph_json, dict) and row.graph_json.get("nodes"):
+        graph = row.graph_json
+    return {
+        "task_id": row.task_id,
+        "status": row.status,
+        "error": row.error,
+        "graph": graph,
+    }
+
+
+def get_mindmap_job_status(db: Session, *, task_id: str) -> dict[str, object]:
+    row = db.query(MindMapJob).filter(MindMapJob.task_id == task_id).first()
+    if row is None:
+        raise ValueError("Mind map job not found")
+    graph: dict | None = None
+    if isinstance(row.graph_json, dict) and row.graph_json.get("nodes"):
+        graph = row.graph_json
+    return {
+        "task_id": row.task_id,
+        "status": row.status,
+        "error": row.error,
+        "graph": graph,
+    }
+
+
+def _score_contexts_for_query(contexts: list[dict[str, str]], query: str, top_k: int = 6) -> list[dict[str, str]]:
+    """Return top_k contexts most relevant to the query by keyword overlap."""
+    tokens = [t for t in re.findall(r"[a-zA-Z0-9]+", query.lower()) if len(t) >= MIN_NODE_TOKEN_LENGTH]
+    if not tokens:
+        return contexts[:top_k]
+    scored: list[tuple[int, dict[str, str]]] = []
+    for ctx in contexts:
+        snippet_lower = ctx.get("snippet", "").lower()
+        score = sum(1 for t in tokens if t in snippet_lower)
+        scored.append((score, ctx))
+    scored.sort(key=lambda x: -x[0])
+    top = [ctx for _, ctx in scored[:top_k]]
+    # If none matched, fall back to first top_k
+    if all(s == 0 for s, _ in scored[:top_k]):
+        return contexts[:top_k]
+    return top
+
+
+async def get_or_generate_node_info(db: Session, *, task_id: str, node_id: str) -> dict[str, object]:
+    row = db.query(MindMapJob).filter(MindMapJob.task_id == task_id).first()
+    if row is None:
+        raise ValueError("Mind map job not found")
+
+    cached_info = (
+        db.query(MindMapNodeInfo)
+        .filter(
+            MindMapNodeInfo.mind_map_job_id == row.id,
+            MindMapNodeInfo.node_id == node_id,
+        )
+        .first()
+    )
+    if cached_info is not None:
+        sources = cached_info.sources_json if isinstance(cached_info.sources_json, list) else []
+        return {"encyclopedic": cached_info.encyclopedic, "interview_prep": cached_info.interview_prep, "sources": sources}
+
+    # Find node label
+    graph = row.graph_json if isinstance(row.graph_json, dict) else {}
+    node_label = ""
+    for node in graph.get("nodes", []):
+        if node.get("id") == node_id:
+            node_label = node.get("label", node_id)
+            break
+    if not node_label:
+        node_label = node_id
+
+    contexts: list[dict[str, str]] = []
+    try:
+        contexts = _collect_all_contexts(db, job_id=row.job_id, doc_id=int(row.doc_id) if row.doc_id is not None else None)
+    except ValueError:
+        pass
+
+    source_contexts = _score_contexts_for_query(contexts, node_label, top_k=4) if contexts else []
+
+    result = await _generate_node_info_llm(node_label, source_contexts)
+
+    node_info = MindMapNodeInfo(
+        mind_map_job_id=row.id,
+        node_id=node_id,
+        encyclopedic=result["encyclopedic"],
+        interview_prep=result["interview_prep"],
+        sources_json=result["sources"],
+    )
+    db.add(node_info)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        cached_info = (
+            db.query(MindMapNodeInfo)
+            .filter(
+                MindMapNodeInfo.mind_map_job_id == row.id,
+                MindMapNodeInfo.node_id == node_id,
+            )
+            .first()
+        )
+        if cached_info is not None:
+            sources = cached_info.sources_json if isinstance(cached_info.sources_json, list) else []
+            return {"encyclopedic": cached_info.encyclopedic, "interview_prep": cached_info.interview_prep, "sources": sources}
+
+    return result
+
+
+async def _generate_node_info_llm(node_label: str, source_contexts: list[dict[str, str]]) -> dict[str, object]:
+    if litellm is None:
+        import litellm as runtime_litellm
+        completion_client = runtime_litellm
+    else:
+        completion_client = litellm
+
+    model, kwargs = llm_service._get_litellm_model()  # type: ignore[attr-defined]
+
+    sources: list[dict[str, object]] = [
+        {"index": i, "filename": ctx.get("filename", f"document-{i}"), "snippet": ctx.get("snippet", "")[:400]}
+        for i, ctx in enumerate(source_contexts, start=1)
+    ]
+
+    excerpts_block = "\n\n".join(
+        f"[{src['index']}] {src['filename']}:\n{src['snippet']}" for src in sources
+    ) or "No document excerpts available."
+
+    prompt = "\n\n".join([
+        "You are an expert technical interview coach.",
+        "Given a concept and relevant document excerpts, produce two things:",
+        "1. encyclopedic: A clear, thorough explanation of what this concept is, how it works, and where it is used. "
+        "Ground it in the provided excerpts and include inline citations like [1] or [2] where applicable.",
+        "2. interview_prep: How to answer questions about this concept in a technical interview. "
+        "Include key talking points, common follow-up questions, and tradeoffs. Use bullet points (• prefix).",
+        'Return exactly one JSON object:\n{"encyclopedic": "...", "interview_prep": "..."}',
+        "Return JSON only (no markdown).",
+        f"concept: {node_label}",
+        f"document_excerpts:\n{excerpts_block}",
+    ])
+
+    response = await completion_client.acompletion(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+        max_tokens=2048,
+        **kwargs,
+    )
+    content = response.choices[0].message.content or ""
+    payload_text = _extract_json_payload(content) or ""
+    if not payload_text.strip():
+        return {"encyclopedic": "", "interview_prep": "", "sources": sources}
+    try:
+        parsed = json.loads(payload_text)
+    except Exception:
+        try:
+            parsed = json.loads(llm_service._sanitize_json_token_stream(payload_text))  # type: ignore[attr-defined]
+        except Exception:
+            parsed = {}
+    if not isinstance(parsed, dict):
+        return {"encyclopedic": "", "interview_prep": "", "sources": sources}
+    return {
+        "encyclopedic": str(parsed.get("encyclopedic") or ""),
+        "interview_prep": str(parsed.get("interview_prep") or ""),
+        "sources": sources,
+    }
+
+
+async def chat_with_mindmap(db: Session, *, task_id: str, message: str) -> dict[str, object]:
+    row = db.query(MindMapJob).filter(MindMapJob.task_id == task_id).first()
+    if row is None:
+        raise ValueError("Mind map job not found")
+
+    contexts: list[dict[str, str]] = []
+    try:
+        contexts = _collect_all_contexts(db, job_id=row.job_id, doc_id=int(row.doc_id) if row.doc_id is not None else None)
+    except ValueError:
+        pass
+
+    if not contexts:
+        return {"answer": "No document content is available for this mind map.", "sources": []}
+
+    top_contexts = _score_contexts_for_query(contexts, message, top_k=6)
+    return await _generate_chat_answer(message, top_contexts)
+
+
+async def _generate_chat_answer(message: str, contexts: list[dict[str, str]]) -> dict[str, object]:
+    if litellm is None:
+        import litellm as runtime_litellm
+        completion_client = runtime_litellm
+    else:
+        completion_client = litellm
+
+    model, kwargs = llm_service._get_litellm_model()  # type: ignore[attr-defined]
+
+    sources: list[dict[str, object]] = [
+        {"index": i, "filename": ctx.get("filename", f"document-{i}"), "snippet": ctx.get("snippet", "")[:400]}
+        for i, ctx in enumerate(contexts, start=1)
+    ]
+
+    excerpts_block = "\n\n".join(
+        f"[{src['index']}] {src['filename']}:\n{src['snippet']}" for src in sources
+    )
+
+    prompt = "\n\n".join([
+        "You are an expert technical interview coach helping a candidate study for interviews.",
+        "Answer the question using the provided document excerpts.",
+        "Include inline citations like [1] or [2] wherever you use information from a source.",
+        "Be thorough but concise. Use bullet points (• prefix) where appropriate.",
+        f"question: {message}",
+        f"document excerpts:\n{excerpts_block}",
+    ])
+
+    response = await completion_client.acompletion(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+        max_tokens=2048,
+        **kwargs,
+    )
+    answer = response.choices[0].message.content or ""
+    return {"answer": answer.strip(), "sources": sources}

--- a/backend/app/services/mindmap.py
+++ b/backend/app/services/mindmap.py
@@ -18,6 +18,7 @@ except ModuleNotFoundError:  # pragma: no cover - test/runtime parity
 
 from ..database import SessionLocal
 from ..models.interview import InterviewKnowledgeDocument
+from ..models.practice import PracticeQuestion
 from ..models.score import Job
 from ..models.study import MindMap, MindMapJob, MindMapNodeInfo
 from . import interview_docs, llm as llm_service
@@ -408,19 +409,42 @@ def get_cached_mind_map(
 # ── New async job-based mind map functions ────────────────────────────────────
 
 
+def _build_chunk_page_map(db: Session, document_id: int) -> dict[int, int | None]:
+    """Return {chunk_index: page_number} for a document's embedded chunks."""
+    rows = (
+        db.query(PracticeQuestion.source_window, PracticeQuestion.chunk_page)
+        .filter(
+            PracticeQuestion.source_table == interview_docs.DOC_TABLE_NAME,
+            PracticeQuestion.source_id == document_id,
+        )
+        .all()
+    )
+    result: dict[int, int | None] = {}
+    for sw, cp in rows:
+        idx = interview_docs.chunk_index_from_source_window(sw)
+        if idx is not None:
+            result[idx] = cp
+    return result
+
+
 def _collect_all_contexts(db: Session, *, job_id: int, doc_id: int | None) -> list[dict[str, str]]:
     selected_docs = _eligible_job_documents(db, job_id=job_id, doc_id=doc_id)
     if not selected_docs:
         raise ValueError("No interview documents available for this selection.")
     contexts: list[dict[str, str]] = []
-    if doc_id is not None:
-        document = selected_docs[0]
+    docs_to_process = [selected_docs[0]] if doc_id is not None else selected_docs
+    for document in docs_to_process:
+        chunk_page_map = _build_chunk_page_map(db, document.id)
         for index, snippet in enumerate(interview_docs.chunk_interview_text(document.parsed_text)):
-            contexts.append({"filename": document.source_filename, "snippet": snippet, "chunk_id": f"{document.id}:chunk:{index}"})
-    else:
-        for document in selected_docs:
-            for index, snippet in enumerate(interview_docs.chunk_interview_text(document.parsed_text)):
-                contexts.append({"filename": document.source_filename, "snippet": snippet, "chunk_id": f"{document.id}:chunk:{index}"})
+            page_num = chunk_page_map.get(index)
+            ctx: dict[str, str] = {
+                "filename": document.source_filename or "",
+                "snippet": snippet,
+                "chunk_id": f"{document.id}:chunk:{index}",
+                "doc_id": str(document.id),
+                "page_number": str(page_num) if page_num is not None else "",
+            }
+            contexts.append(ctx)
     if not contexts:
         raise ValueError("No interview document content available for mind map extraction.")
     return contexts
@@ -713,7 +737,13 @@ async def _generate_node_info_llm(node_label: str, source_contexts: list[dict[st
     model, kwargs = llm_service._get_litellm_model()  # type: ignore[attr-defined]
 
     sources: list[dict[str, object]] = [
-        {"index": i, "filename": ctx.get("filename", f"document-{i}"), "snippet": ctx.get("snippet", "")[:400]}
+        {
+            "index": i,
+            "filename": ctx.get("filename", f"document-{i}"),
+            "snippet": ctx.get("snippet", "")[:400],
+            "doc_id": int(ctx["doc_id"]) if ctx.get("doc_id") else None,
+            "page_number": int(ctx["page_number"]) if ctx.get("page_number") else None,
+        }
         for i, ctx in enumerate(source_contexts, start=1)
     ]
 
@@ -789,7 +819,13 @@ async def _generate_chat_answer(message: str, contexts: list[dict[str, str]]) ->
     model, kwargs = llm_service._get_litellm_model()  # type: ignore[attr-defined]
 
     sources: list[dict[str, object]] = [
-        {"index": i, "filename": ctx.get("filename", f"document-{i}"), "snippet": ctx.get("snippet", "")[:400]}
+        {
+            "index": i,
+            "filename": ctx.get("filename", f"document-{i}"),
+            "snippet": ctx.get("snippet", "")[:400],
+            "doc_id": int(ctx["doc_id"]) if ctx.get("doc_id") else None,
+            "page_number": int(ctx["page_number"]) if ctx.get("page_number") else None,
+        }
         for i, ctx in enumerate(contexts, start=1)
     ]
 

--- a/backend/app/services/practice_embedder.py
+++ b/backend/app/services/practice_embedder.py
@@ -92,6 +92,7 @@ def _build_document_row(
     document: InterviewKnowledgeDocument,
     chunk_index: int,
     source_window: str,
+    chunk_page: int | None = None,
 ) -> PracticeQuestion:
     scope_type = "global" if (document.owner_type or "global") == "global" else "job"
     return PracticeQuestion(
@@ -105,19 +106,37 @@ def _build_document_row(
         source_table=interview_docs.DOC_TABLE_NAME,
         source_id=document.id,
         source_window=source_window,
+        chunk_page=chunk_page,
     )
+
+
+def _get_page_word_offsets(document: InterviewKnowledgeDocument) -> list[int]:
+    """Read the stored file (if available) and return page word offsets for page-aware chunking."""
+    if not document.file_path:
+        return [0]
+    try:
+        from pathlib import Path
+        from .cv_parser import parse_cv_with_pages
+        file_bytes = Path(document.file_path).read_bytes()
+        _, page_offsets = parse_cv_with_pages(file_bytes, document.source_filename or "document.pdf")
+        return page_offsets or [0]
+    except Exception:
+        return [0]
 
 
 def _prepare_document_rows_for_embedding(
     db: Session,
     document: InterviewKnowledgeDocument,
 ) -> list[tuple[PracticeQuestion, str]]:
-    chunks = interview_docs.chunk_interview_text(document.parsed_text)
-    if not chunks:
+    page_offsets = _get_page_word_offsets(document)
+    chunks_with_pages = interview_docs.chunk_interview_text_with_pages(
+        document.parsed_text, page_offsets
+    )
+    if not chunks_with_pages:
         return []
 
     scoped_rows: list[tuple[PracticeQuestion, str]] = []
-    for chunk_index, chunk_text in enumerate(chunks):
+    for chunk_index, (chunk_text, chunk_page) in enumerate(chunks_with_pages):
         source_window = interview_docs.make_source_window(chunk_index)
         existing = (
             db.query(PracticeQuestion)
@@ -133,6 +152,7 @@ def _prepare_document_rows_for_embedding(
                 document=document,
                 chunk_index=chunk_index,
                 source_window=source_window,
+                chunk_page=chunk_page,
             )
             db.add(existing)
             db.flush()
@@ -140,6 +160,9 @@ def _prepare_document_rows_for_embedding(
             continue
         if existing.embedding is not None:
             continue
+        # Backfill page if missing
+        if existing.chunk_page is None:
+            existing.chunk_page = chunk_page
         scoped_rows.append((existing, chunk_text))
 
     return scoped_rows

--- a/backend/tests/test_mindmap_service.py
+++ b/backend/tests/test_mindmap_service.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import sys
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.database import Base
+from app.models.interview import InterviewKnowledgeDocument
+from app.models.score import Job
+from app.models.study import MindMap
+from app.services import mindmap
+
+
+def _new_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            Job.__table__,
+            InterviewKnowledgeDocument.__table__,
+            MindMap.__table__,
+        ],
+    )
+    return sessionmaker(bind=engine)()
+
+
+def _seed_job_and_doc(db):
+    job = Job(id=77, title="Backend Engineer", company="Acme", description="Build distributed services.")
+    document = InterviewKnowledgeDocument(
+        id=301,
+        owner_type="job",
+        job_id=77,
+        source_filename="notes.md",
+        content_type="text/markdown",
+        parsed_text=(
+            "Distributed systems need consistency and availability.\n"
+            "Queues smooth traffic spikes and support retries.\n"
+            "Caching can reduce database load."
+        ),
+        status="embedded",
+    )
+    db.add(job)
+    db.add(document)
+    db.commit()
+    return job, document
+
+
+@pytest.mark.asyncio
+async def test_generate_or_get_mind_map_caches_by_content_hash(monkeypatch):
+    db = _new_session()
+    _seed_job_and_doc(db)
+    call_count = {"value": 0}
+
+    async def _fake_generate(_contexts):
+        call_count["value"] += 1
+        return {
+            "nodes": [{"id": "distributed_systems", "label": "Distributed Systems", "group": "system_design"}],
+            "edges": [],
+        }
+
+    monkeypatch.setattr(mindmap, "_generate_graph_from_contexts", _fake_generate)
+
+    first, cached_first = await mindmap.generate_or_get_mind_map(db, job_id=77, doc_id=301)
+    second, cached_second = await mindmap.generate_or_get_mind_map(db, job_id=77, doc_id=301)
+
+    assert cached_first is False
+    assert cached_second is True
+    assert first["content_hash"] == second["content_hash"]
+    assert call_count["value"] == 1
+    assert db.query(MindMap).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_get_cached_mind_map_requires_current_content_hash(monkeypatch):
+    db = _new_session()
+    _, document = _seed_job_and_doc(db)
+
+    async def _fake_generate(_contexts):
+        return {
+            "nodes": [{"id": "queues", "label": "Queues", "group": "architecture"}],
+            "edges": [],
+        }
+
+    monkeypatch.setattr(mindmap, "_generate_graph_from_contexts", _fake_generate)
+
+    generated, _ = await mindmap.generate_or_get_mind_map(db, job_id=77, doc_id=301)
+    assert generated["graph"]["nodes"][0]["id"] == "queues"
+
+    # Simulate document content update after cached graph creation.
+    document.parsed_text = document.parsed_text + "\nNew section on idempotency."
+    db.add(document)
+    db.commit()
+
+    with pytest.raises(ValueError, match="not found"):
+        mindmap.get_cached_mind_map(db, job_id=77, doc_id=301)

--- a/backend/tests/test_study_router.py
+++ b/backend/tests/test_study_router.py
@@ -12,7 +12,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 from app.database import Base
 from app.models.interview import InterviewKnowledgeDocument
 from app.models.score import Job
-from app.models.study import StudyCard, StudyCardSet, StudyCardSetDocument
+from app.models.study import MindMap, StudyCard, StudyCardSet, StudyCardSetDocument
 from app.routers import study as study_router
 
 
@@ -26,6 +26,7 @@ def _new_session():
             StudyCardSet.__table__,
             StudyCard.__table__,
             StudyCardSetDocument.__table__,
+            MindMap.__table__,
         ],
     )
     return sessionmaker(bind=engine)()
@@ -235,3 +236,63 @@ def test_delete_card_set_route(monkeypatch):
     monkeypatch.setattr(study_router.flashcards, "delete_study_card_set", _fake_delete)
     response = study_router.delete_card_set(5, db=db)
     assert response["status"] == "deleted"
+
+
+def test_get_mindmap_route_returns_payload(monkeypatch):
+    db = _new_session()
+
+    def _fake_get_cached(db_session, *, job_id: int, doc_id: int | None):
+        return {
+            "id": 1,
+            "job_id": job_id,
+            "doc_id": doc_id,
+            "content_hash": "abc123",
+            "graph": {
+                "nodes": [{"id": "distributed_systems", "label": "Distributed Systems", "group": "system_design"}],
+                "edges": [],
+            },
+            "node_sources": {"distributed_systems": "Distributed systems interview notes"},
+            "created_at": "2026-03-19T12:00:00+00:00",
+        }
+
+    monkeypatch.setattr(study_router.mindmap, "get_cached_mind_map", _fake_get_cached)
+
+    response = study_router.get_mindmap(job_id=9, doc_id=3, db=db)
+
+    assert response.job_id == 9
+    assert response.doc_id == 3
+    assert response.cached is True
+    assert response.graph.nodes[0].id == "distributed_systems"
+
+
+@pytest.mark.asyncio
+async def test_create_or_get_mindmap_route_happy_path(monkeypatch):
+    db = _new_session()
+
+    async def _fake_generate(db_session, *, job_id: int, doc_id: int | None):
+        return (
+            {
+                "id": 11,
+                "job_id": job_id,
+                "doc_id": doc_id,
+                "content_hash": "hash-1",
+                "graph": {
+                    "nodes": [{"id": "queues", "label": "Queues", "group": "system_design"}],
+                    "edges": [{"source": "queues", "target": "queues", "label": "related_to"}],
+                },
+                "node_sources": {"queues": "Queue notes"},
+                "created_at": "2026-03-19T12:00:00+00:00",
+            },
+            False,
+        )
+
+    monkeypatch.setattr(study_router.mindmap, "generate_or_get_mind_map", _fake_generate)
+
+    response = await study_router.create_or_get_mindmap(
+        payload=study_router.MindMapRequest(job_id=5, doc_id=None),
+        db=db,
+    )
+
+    assert response.job_id == 5
+    assert response.cached is False
+    assert response.graph.nodes[0].id == "queues"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,8 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-COPY package.json .
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 COPY . .
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vett-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@dagrejs/dagre": "^1.1.4",
         "@huggingface/transformers": "^3.5.1",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
@@ -21,6 +22,7 @@
         "reactflow": "^11.11.4"
       },
       "devDependencies": {
+        "@types/dagre": "^0.7.52",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -324,6 +326,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.8.tgz",
+      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2193,6 +2213,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/dagre": {
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.5",
         "react-hot-toast": "^2.4.1",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.28.0",
+        "reactflow": "^11.11.4"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -1427,6 +1428,108 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1838,11 +1941,270 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1858,14 +2220,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2165,6 +2527,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2221,6 +2589,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3557,6 +4030,24 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4069,6 +4560,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4188,6 +4688,34 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,9 +20,11 @@
     "react-dropzone": "^14.3.5",
     "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.28.0",
-    "reactflow": "^11.11.4"
+    "reactflow": "^11.11.4",
+    "@dagrejs/dagre": "^1.1.4"
   },
   "devDependencies": {
+    "@types/dagre": "^0.7.52",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.5.1",
+    "axios": "^1.7.9",
+    "clsx": "^2.1.1",
+    "kokoro-js": "^1.2.1",
+    "lucide-react": "^0.462.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0",
-    "axios": "^1.7.9",
     "react-dropzone": "^14.3.5",
     "react-hot-toast": "^2.4.1",
-    "clsx": "^2.1.1",
-    "lucide-react": "^0.462.0",
-    "kokoro-js": "^1.2.1",
-    "@huggingface/transformers": "^3.5.1"
+    "react-router-dom": "^6.28.0",
+    "reactflow": "^11.11.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import JobDetails from './pages/JobDetails'
 import InterviewPrep from './pages/InterviewPrep'
 import StudyHub from './pages/StudyHub'
 import StudyDecks from './pages/StudyDecks'
+import StudyMindMap from './pages/StudyMindMap'
 import Settings from './pages/Settings'
 import SolvePractice from './pages/SolvePractice'
 
@@ -25,6 +26,7 @@ export default function App() {
         <Route path="jobs/:id/interview-prep/voice" element={<InterviewPrep />} />
         <Route path="study" element={<StudyHub />} />
         <Route path="study/flashcards" element={<StudyDecks />} />
+        <Route path="study/mindmap" element={<StudyMindMap />} />
         <Route path="practice/coach" element={<SolvePractice />} />
         <Route path="settings" element={<Settings />} />
       </Route>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -725,6 +725,39 @@ export interface FlashcardSetItem {
   card_set: StudyCardSetSummary
 }
 
+export interface MindMapNode {
+  id: string
+  label: string
+  group: string
+}
+
+export interface MindMapEdge {
+  source: string
+  target: string
+  label: string
+}
+
+export interface MindMapGraph {
+  nodes: MindMapNode[]
+  edges: MindMapEdge[]
+}
+
+export interface StudyMindMapResponse {
+  id: number
+  job_id: number
+  doc_id: number | null
+  content_hash: string
+  graph: MindMapGraph
+  node_sources: Record<string, string>
+  created_at: string | null
+  cached: boolean
+}
+
+export interface GenerateStudyMindMapRequest {
+  job_id: number
+  doc_id?: number | null
+}
+
 export interface StudyCardSetRenameRequest {
   name: string
 }
@@ -903,6 +936,21 @@ export const renameStudyCardSet = async (
 
 export const deleteStudyCardSet = async (cardSetId: number): Promise<void> => {
   await api.delete(`/study/card-sets/${cardSetId}`)
+}
+
+export const generateStudyMindMap = async (request: GenerateStudyMindMapRequest): Promise<StudyMindMapResponse> => {
+  const { data } = await api.post<StudyMindMapResponse>('/study/mindmap', request, { timeout: 120000 })
+  return data
+}
+
+export const getStudyMindMap = async (
+  jobId: number,
+  docId?: number | null,
+): Promise<StudyMindMapResponse> => {
+  const { data } = await api.get<StudyMindMapResponse>('/study/mindmap', {
+    params: { job_id: jobId, doc_id: docId ?? undefined },
+  })
+  return data
 }
 
 // ── Practice (Phase 1) ─────────────────────────────────────────────────────────

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -751,11 +751,42 @@ export interface StudyMindMapResponse {
   node_sources: Record<string, string>
   created_at: string | null
   cached: boolean
+  task_id: string | null
 }
 
 export interface GenerateStudyMindMapRequest {
-  job_id: number
+  job_id?: number | null
   doc_id?: number | null
+}
+
+export interface MindMapJobStartResponse {
+  task_id: string
+  status: string
+}
+
+export interface MindMapJobStatusResponse {
+  task_id: string
+  status: 'pending' | 'processing' | 'done' | 'failed'
+  error?: string | null
+  graph?: MindMapGraph | null
+}
+
+export interface MindMapNodeSource {
+  index: number
+  filename: string
+  snippet: string
+}
+
+export interface MindMapNodeInfoResponse {
+  node_id: string
+  encyclopedic: string
+  interview_prep: string
+  sources: MindMapNodeSource[]
+}
+
+export interface MindMapChatResponse {
+  answer: string
+  sources: MindMapNodeSource[]
 }
 
 export interface StudyCardSetRenameRequest {
@@ -950,6 +981,37 @@ export const getStudyMindMap = async (
   const { data } = await api.get<StudyMindMapResponse>('/study/mindmap', {
     params: { job_id: jobId, doc_id: docId ?? undefined },
   })
+  return data
+}
+
+export const startMindMapJob = async (request: GenerateStudyMindMapRequest): Promise<MindMapJobStartResponse> => {
+  const { data } = await api.post<MindMapJobStartResponse>('/study/mindmap', request)
+  return data
+}
+
+export const getMindMapJobStatus = async (taskId: string): Promise<MindMapJobStatusResponse> => {
+  const { data } = await api.get<MindMapJobStatusResponse>(`/study/mindmap/status/${encodeURIComponent(taskId)}`)
+  return data
+}
+
+export const getLatestMindMapJob = async (params: { job_id?: number | null; doc_id?: number | null }): Promise<MindMapJobStatusResponse> => {
+  const { data } = await api.get<MindMapJobStatusResponse>('/study/mindmap/latest', { params })
+  return data
+}
+
+export const getMindMapNodeInfo = async (taskId: string, nodeId: string): Promise<MindMapNodeInfoResponse> => {
+  const { data } = await api.get<MindMapNodeInfoResponse>(
+    `/study/mindmap/${encodeURIComponent(taskId)}/node/${encodeURIComponent(nodeId)}`,
+  )
+  return data
+}
+
+export const chatMindMap = async (taskId: string, message: string): Promise<MindMapChatResponse> => {
+  const { data } = await api.post<MindMapChatResponse>(
+    `/study/mindmap/${encodeURIComponent(taskId)}/chat`,
+    { message },
+    { timeout: 60000 },
+  )
   return data
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -775,6 +775,8 @@ export interface MindMapNodeSource {
   index: number
   filename: string
   snippet: string
+  doc_id: number | null
+  page_number: number | null
 }
 
 export interface MindMapNodeInfoResponse {

--- a/frontend/src/pages/StudyHub.tsx
+++ b/frontend/src/pages/StudyHub.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Bot, BookOpen, BrainCircuit } from 'lucide-react'
+import { Bot, BookOpen, BrainCircuit, Network } from 'lucide-react'
 
 const modules = [
   {
@@ -19,6 +19,15 @@ const modules = [
     cta: 'Coming soon',
     disabled: true,
     icon: BrainCircuit,
+  },
+  {
+    id: 'mindmap',
+    title: 'Concept Mind Map',
+    description: 'Extract and explore a concept graph from interview knowledge documents.',
+    to: '/study/mindmap',
+    cta: 'Open Mind Map',
+    disabled: false,
+    icon: Network,
   },
   {
     id: 'interview',

--- a/frontend/src/pages/StudyMindMap.tsx
+++ b/frontend/src/pages/StudyMindMap.tsx
@@ -184,20 +184,36 @@ function SourcesAccordion({
       </button>
       {open && (
         <div className="divide-y divide-border">
-          {sources.map((src) => (
-            <div
-              key={src.index}
-              className={`px-3 py-2 space-y-1 transition-colors ${highlightIndex === src.index ? 'bg-accent/10' : ''}`}
-            >
-              <div className="flex items-center gap-1.5">
-                <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-accent/20 text-accent shrink-0">
-                  {src.index}
-                </span>
-                <span className="font-medium text-text-primary truncate">{src.filename}</span>
+          {sources.map((src) => {
+            const pdfUrl = src.doc_id
+              ? `/api/interview-documents/${src.doc_id}/file${src.page_number ? `#page=${src.page_number}` : ''}`
+              : null
+            return (
+              <div
+                key={src.index}
+                className={`px-3 py-2 space-y-1 transition-colors ${highlightIndex === src.index ? 'bg-accent/10' : ''}`}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-accent/20 text-accent shrink-0">
+                    {src.index}
+                  </span>
+                  {pdfUrl ? (
+                    <a
+                      href={pdfUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-accent hover:underline truncate"
+                    >
+                      {src.filename}{src.page_number ? ` · p.${src.page_number}` : ''}
+                    </a>
+                  ) : (
+                    <span className="font-medium text-text-primary truncate">{src.filename}</span>
+                  )}
+                </div>
+                <p className="text-text-muted leading-relaxed line-clamp-3">{src.snippet}</p>
               </div>
-              <p className="text-text-muted leading-relaxed line-clamp-3">{src.snippet}</p>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/pages/StudyMindMap.tsx
+++ b/frontend/src/pages/StudyMindMap.tsx
@@ -1,111 +1,344 @@
-import { useEffect, useMemo, useState } from 'react'
-import ReactFlow, { Background, Controls, type Edge, type Node, Position } from 'reactflow'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import ReactFlow, {
+  Background,
+  Controls,
+  type Edge,
+  Handle,
+  type Node,
+  type NodeProps,
+  Position,
+} from 'reactflow'
 import 'reactflow/dist/style.css'
-import { Loader2, Network, RefreshCcw } from 'lucide-react'
+import dagre from '@dagrejs/dagre'
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Loader2, Network, Send } from 'lucide-react'
 import toast from 'react-hot-toast'
 
 import {
-  generateStudyMindMap,
+  chatMindMap,
+  getLatestMindMapJob,
+  getMindMapJobStatus,
+  getMindMapNodeInfo,
   getInterviewDocuments,
-  getJobInterviewDocuments,
-  getStudyMindMap,
+  startMindMapJob,
   type InterviewKnowledgeDocument,
-  type StudyMindMapResponse,
+  type MindMapNodeInfoResponse,
+  type MindMapNodeSource,
 } from '../lib/api'
 
-type MapStatus = 'idle' | 'loading' | 'ready'
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+type MapStatus = 'idle' | 'generating' | 'ready' | 'failed'
+
+const NODE_WIDTH = 200
+const NODE_HEIGHT = 40
+
+// NotebookLM-style dark palette: bg, border, text, selectedBg
+const GROUP_PALETTE = [
+  { bg: '#2A3A2E', border: '#4A7C59', text: '#D4EDD9', selectedBg: '#3A5A42' }, // root – deep green
+  { bg: '#1E2A38', border: '#3D6B9E', text: '#C8DCEF', selectedBg: '#2A3D55' }, // main – blue
+  { bg: '#2E2218', border: '#8A5C2A', text: '#F0DEC4', selectedBg: '#44321E' }, // detail – amber
+  { bg: '#2A1E38', border: '#6B4A9E', text: '#DEC8EF', selectedBg: '#3D2A55' }, // purple
+  { bg: '#1E2E2E', border: '#2E8A7A', text: '#C4EDE9', selectedBg: '#1E4040' }, // teal
+  { bg: '#2E1E24', border: '#9E3D5C', text: '#EFC8D4', selectedBg: '#441826' }, // rose
+]
+
+// ── Custom node ────────────────────────────────────────────────────────────────
+
+interface MindMapNodeData {
+  label: string
+  palette: typeof GROUP_PALETTE[number]
+  isSelected: boolean
+  isRoot: boolean
+  hasChildren: boolean
+  isExpanded: boolean
+  onToggle: (id: string) => void
+}
+
+function MindMapNode({ id, data }: NodeProps<MindMapNodeData>) {
+  const { label, palette, isSelected, isRoot, hasChildren, isExpanded, onToggle } = data
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: `1.5px solid ${isSelected ? palette.border : palette.border + 'BB'}`,
+        background: isSelected ? palette.selectedBg : palette.bg,
+        color: palette.text,
+        fontSize: isRoot ? 13 : 12,
+        fontWeight: isRoot ? 700 : isSelected ? 600 : 400,
+        padding: '7px 10px 7px 14px',
+        width: isRoot ? NODE_WIDTH + 20 : NODE_WIDTH,
+        minHeight: NODE_HEIGHT,
+        boxShadow: isSelected
+          ? `0 0 0 3px ${palette.border}55, 0 4px 12px rgba(0,0,0,0.4)`
+          : '0 2px 6px rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 6,
+        cursor: 'pointer',
+        transition: 'all 0.15s ease',
+      }}
+    >
+      <Handle type="target" position={Position.Left} style={{ background: palette.border, width: 6, height: 6 }} />
+      <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</span>
+      {hasChildren && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onToggle(id) }}
+          style={{
+            background: palette.border + '33',
+            border: `1px solid ${palette.border}88`,
+            borderRadius: 4,
+            color: palette.text,
+            width: 20,
+            height: 20,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            cursor: 'pointer',
+          }}
+        >
+          {isExpanded
+            ? <ChevronLeft style={{ width: 11, height: 11 }} />
+            : <ChevronRight style={{ width: 11, height: 11 }} />}
+        </button>
+      )}
+      <Handle type="source" position={Position.Right} style={{ background: palette.border, width: 6, height: 6 }} />
+    </div>
+  )
+}
+
+const NODE_TYPES = { mindmap: MindMapNode }
+
+// ── Dagre LR layout ────────────────────────────────────────────────────────────
+
+function applyDagreLayout(nodes: Node[], edges: Edge[]): Node[] {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'LR', ranksep: 100, nodesep: 32, marginx: 60, marginy: 60 })
+  nodes.forEach((n) => {
+    const w = (n.data as MindMapNodeData).isRoot ? NODE_WIDTH + 20 : NODE_WIDTH
+    g.setNode(n.id, { width: w, height: NODE_HEIGHT })
+  })
+  edges.forEach((e) => g.setEdge(e.source, e.target))
+  dagre.layout(g)
+  return nodes.map((n) => {
+    const pos = g.node(n.id)
+    const w = (n.data as MindMapNodeData).isRoot ? NODE_WIDTH + 20 : NODE_WIDTH
+    return { ...n, position: { x: pos.x - w / 2, y: pos.y - NODE_HEIGHT / 2 } }
+  })
+}
+
+// ── Citation rendering ─────────────────────────────────────────────────────────
+
+function CitationChip({ index, onClick }: { index: number; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center justify-center w-5 h-5 rounded text-[10px] font-semibold bg-accent/20 text-accent hover:bg-accent/30 transition-colors align-middle"
+    >
+      {index}
+    </button>
+  )
+}
+
+/** Render text with [N] markers as clickable citation chips */
+function CitedText({ text, onCitationClick }: { text: string; onCitationClick: (index: number) => void }) {
+  const parts = text.split(/(\[\d+\])/g)
+  return (
+    <span>
+      {parts.map((part, i) => {
+        const match = /^\[(\d+)\]$/.exec(part)
+        if (match) {
+          const idx = Number(match[1])
+          return <CitationChip key={i} index={idx} onClick={() => onCitationClick(idx)} />
+        }
+        return <span key={i}>{part}</span>
+      })}
+    </span>
+  )
+}
+
+// ── Sources accordion ──────────────────────────────────────────────────────────
+
+function SourcesAccordion({
+  sources,
+  highlightIndex,
+}: {
+  sources: MindMapNodeSource[]
+  highlightIndex: number | null
+}) {
+  const [open, setOpen] = useState(false)
+  if (!sources.length) return null
+  return (
+    <div className="border border-border rounded-lg overflow-hidden text-xs">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-2 bg-bg-secondary hover:bg-bg-tertiary transition-colors"
+      >
+        <span className="font-medium text-text-secondary">Sources ({sources.length})</span>
+        {open ? <ChevronUp className="w-3.5 h-3.5 text-text-muted" /> : <ChevronDown className="w-3.5 h-3.5 text-text-muted" />}
+      </button>
+      {open && (
+        <div className="divide-y divide-border">
+          {sources.map((src) => (
+            <div
+              key={src.index}
+              className={`px-3 py-2 space-y-1 transition-colors ${highlightIndex === src.index ? 'bg-accent/10' : ''}`}
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-accent/20 text-accent shrink-0">
+                  {src.index}
+                </span>
+                <span className="font-medium text-text-primary truncate">{src.filename}</span>
+              </div>
+              <p className="text-text-muted leading-relaxed line-clamp-3">{src.snippet}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Chat message ───────────────────────────────────────────────────────────────
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+  sources?: MindMapNodeSource[]
+}
+
+function ChatBubble({ msg }: { msg: ChatMessage }) {
+  const [citationHighlight, setCitationHighlight] = useState<number | null>(null)
+
+  if (msg.role === 'user') {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] bg-accent text-white rounded-2xl rounded-tr-sm px-3 py-2 text-sm leading-relaxed">
+          {msg.content}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="max-w-[95%] bg-bg-secondary rounded-2xl rounded-tl-sm px-3 py-2 text-sm leading-relaxed text-text-primary space-y-1.5">
+        {msg.content.split('\n').map((line, i) => {
+          const trimmed = line.trim()
+          if (trimmed.startsWith('•') || trimmed.startsWith('-') || trimmed.startsWith('*')) {
+            return (
+              <div key={i} className="flex gap-2">
+                <span className="text-accent shrink-0 mt-0.5">•</span>
+                <CitedText text={trimmed.replace(/^[•\-*]\s*/, '')} onCitationClick={setCitationHighlight} />
+              </div>
+            )
+          }
+          if (!trimmed) return null
+          return (
+            <p key={i}>
+              <CitedText text={line} onCitationClick={setCitationHighlight} />
+            </p>
+          )
+        })}
+      </div>
+      {msg.sources && msg.sources.length > 0 && (
+        <SourcesAccordion sources={msg.sources} highlightIndex={citationHighlight} />
+      )}
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
 
 export default function StudyMindMap() {
-  const [jobIdInput, setJobIdInput] = useState('')
-  const [jobId, setJobId] = useState<number | null>(null)
   const [documents, setDocuments] = useState<InterviewKnowledgeDocument[]>([])
   const [selectedDocId, setSelectedDocId] = useState<number | null>(null)
-  const [mindMap, setMindMap] = useState<StudyMindMapResponse | null>(null)
+  const [graph, setGraph] = useState<{ nodes: { id: string; label: string; group: string }[]; edges: { source: string; target: string; label: string }[] } | null>(null)
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [status, setStatus] = useState<MapStatus>('idle')
   const [isGenerating, setIsGenerating] = useState(false)
-  const [isCurrentSelectionCached, setIsCurrentSelectionCached] = useState(false)
   const [error, setError] = useState('')
+  const [taskId, setTaskId] = useState<string | null>(null)
+  const [nodeInfoCache, setNodeInfoCache] = useState<Record<string, MindMapNodeInfoResponse>>({})
+
+  // Chat state
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
+  const [chatInput, setChatInput] = useState('')
+  const [isChatLoading, setIsChatLoading] = useState(false)
+  const [chatOpen, setChatOpen] = useState(false)
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set())
+  const chatEndRef = useRef<HTMLDivElement>(null)
 
   const extractErrorMessage = (errorValue: unknown): string => {
     const typed = errorValue as { response?: { data?: { detail?: string } }; message?: string }
     return typed?.response?.data?.detail || typed?.message || 'Request failed'
   }
 
-  const loadSelection = async (nextJobId: number, nextDocId: number | null) => {
-    setStatus('loading')
-    setError('')
-    setMindMap(null)
-    setSelectedNodeId(null)
-    try {
-      const data = await getStudyMindMap(nextJobId, nextDocId)
-      setMindMap(data)
-      setIsCurrentSelectionCached(true)
-      setStatus('ready')
-    } catch (err: unknown) {
-      const message = extractErrorMessage(err)
-      if (message.toLowerCase().includes('not found')) {
-        setIsCurrentSelectionCached(false)
-        setStatus('idle')
-        return
-      }
-      setError(message)
-      setStatus('idle')
-    }
-  }
-
-  const loadDocuments = async (nextJobId: number) => {
-    try {
-      const [globalDocs, jobDocs] = await Promise.all([
-        getInterviewDocuments(),
-        getJobInterviewDocuments(nextJobId),
-      ])
-      const seen = new Set<number>()
-      const merged = [...jobDocs, ...globalDocs].filter((doc) => {
-        if (seen.has(doc.id)) return false
-        seen.add(doc.id)
-        return true
-      })
-      setDocuments(merged)
-      if (selectedDocId && merged.every((doc) => doc.id !== selectedDocId)) {
-        setSelectedDocId(null)
-      }
-    } catch {
-      setDocuments([])
-    }
-  }
-
+  // Auto-scroll chat
   useEffect(() => {
-    if (!jobId) return
-    void loadDocuments(jobId)
-    void loadSelection(jobId, selectedDocId)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobId, selectedDocId])
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [chatMessages])
 
-  const applyJobId = () => {
-    const parsed = Number(jobIdInput)
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      toast.error('Enter a valid job id.')
-      return
-    }
-    setJobId(parsed)
-  }
+  // Polling during generation
+  useEffect(() => {
+    if (!taskId || status !== 'generating') return
+    const interval = setInterval(async () => {
+      try {
+        const result = await getMindMapJobStatus(taskId)
+        if (result.graph?.nodes?.length) setGraph(result.graph)
+        if (result.status === 'done' || result.status === 'failed') {
+          clearInterval(interval)
+          setStatus(result.status === 'done' ? 'ready' : 'failed')
+          if (result.error) setError(result.error)
+        }
+      } catch { /* swallow poll errors */ }
+    }, 2500)
+    return () => clearInterval(interval)
+  }, [taskId, status])
+
+  // Load documents on mount
+  useEffect(() => {
+    getInterviewDocuments()
+      .then(setDocuments)
+      .catch(() => setDocuments([]))
+  }, [])
+
+  // Auto-load latest cached map when doc selection changes
+  useEffect(() => {
+    setError('')
+    setGraph(null)
+    setSelectedNodeId(null)
+    setTaskId(null)
+    if (!selectedDocId) return
+    getLatestMindMapJob({ doc_id: selectedDocId })
+      .then((result) => {
+        if (result.graph?.nodes?.length) {
+          setGraph(result.graph)
+          setTaskId(result.task_id)
+          setStatus('ready')
+        }
+      })
+      .catch(() => { /* no cached map yet — that's fine */ })
+  }, [selectedDocId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleGenerate = async () => {
-    if (!jobId) {
-      toast.error('Enter a job id first.')
-      return
-    }
+    if (!selectedDocId) { toast.error('Select a document first.'); return }
     setIsGenerating(true)
     setError('')
+    setGraph(null)
+    setSelectedNodeId(null)
+    setNodeInfoCache({})
+    setChatMessages([])
     try {
-      const payload = await generateStudyMindMap({ job_id: jobId, doc_id: selectedDocId ?? null })
-      setMindMap(payload)
-      setStatus('ready')
-      setIsCurrentSelectionCached(true)
-      setSelectedNodeId(payload.graph.nodes[0]?.id ?? null)
-      toast.success(payload.cached ? 'Loaded cached mind map.' : 'Mind map generated.')
-    } catch (err: unknown) {
+      const { task_id } = await startMindMapJob({ doc_id: selectedDocId })
+      setTaskId(task_id)
+      setStatus('generating')
+    } catch (err) {
       const message = extractErrorMessage(err)
       setError(message)
       toast.error(message)
@@ -114,163 +347,297 @@ export default function StudyMindMap() {
     }
   }
 
-  const flowNodes: Node[] = useMemo(() => {
-    if (!mindMap) return []
-    const groups = Array.from(new Set(mindMap.graph.nodes.map((node) => node.group || 'general')))
-    const groupIndex = new Map(groups.map((group, index) => [group, index]))
-    return mindMap.graph.nodes.map((node, index) => {
-      const group = node.group || 'general'
-      const row = Math.floor(index / 4)
-      const col = index % 4
-      return {
-        id: node.id,
-        data: { label: node.label },
-        sourcePosition: Position.Right,
-        targetPosition: Position.Left,
-        position: {
-          x: col * 240 + (groupIndex.get(group) ?? 0) * 20,
-          y: row * 130 + (groupIndex.get(group) ?? 0) * 20,
-        },
-        style: {
-          borderRadius: 10,
-          border: '1px solid #A1B39A',
-          background: '#F4F9F2',
-          color: '#29342F',
-          fontSize: 12,
-          padding: 10,
-          width: 200,
-        },
+  const handleNodeClick = async (_: unknown, node: Node) => {
+    setSelectedNodeId(node.id)
+    if (!taskId) return
+    setChatOpen(true)
+    const nodeLabel = graph?.nodes.find((n) => n.id === node.id)?.label ?? node.id
+    const question = `Tell me about "${nodeLabel}" in the context of this document.`
+    setChatInput('')
+    setChatMessages((prev) => [...prev, { role: 'user', content: question }])
+    setIsChatLoading(true)
+    try {
+      if (!nodeInfoCache[node.id]) {
+        getMindMapNodeInfo(taskId, node.id)
+          .then((info) => setNodeInfoCache((prev) => ({ ...prev, [node.id]: info })))
+          .catch(() => {})
       }
+      const response = await chatMindMap(taskId, question)
+      setChatMessages((prev) => [...prev, { role: 'assistant', content: response.answer, sources: response.sources }])
+    } catch {
+      setChatMessages((prev) => [...prev, { role: 'assistant', content: 'Could not load a response. Try again.', sources: [] }])
+    } finally {
+      setIsChatLoading(false)
+    }
+  }
+
+  const handleChatSubmit = async () => {
+    const message = chatInput.trim()
+    if (!message || !taskId || isChatLoading) return
+    setChatInput('')
+    setChatMessages((prev) => [...prev, { role: 'user', content: message }])
+    setIsChatLoading(true)
+    try {
+      const response = await chatMindMap(taskId, message)
+      setChatMessages((prev) => [...prev, { role: 'assistant', content: response.answer, sources: response.sources }])
+    } catch {
+      setChatMessages((prev) => [...prev, { role: 'assistant', content: 'Could not load a response. Try again.', sources: [] }])
+    } finally {
+      setIsChatLoading(false)
+    }
+  }
+
+  // ── Graph layout ─────────────────────────────────────────────────────────────
+
+  // Build child map from edges
+  const childMap = useMemo(() => {
+    const map = new Map<string, string[]>()
+    if (!graph) return map
+    graph.nodes.forEach((n) => map.set(n.id, []))
+    graph.edges.forEach((e) => map.get(e.source)?.push(e.target))
+    return map
+  }, [graph])
+
+  // Reset expanded state when a new graph loads
+  useEffect(() => {
+    if (!graph) return
+    setExpandedNodes(new Set())
+  }, [graph])
+
+  const handleToggle = (id: string) => {
+    setExpandedNodes((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
     })
-  }, [mindMap])
+  }
+
+  // BFS: only include nodes reachable through expanded parents
+  const visibleNodeIds = useMemo(() => {
+    if (!graph) return new Set<string>()
+    const rootId = graph.nodes.find((n) => n.id === 'root' || n.group === 'root')?.id ?? graph.nodes[0]?.id
+    if (!rootId) return new Set<string>()
+    const visible = new Set<string>([rootId])
+    const queue = [rootId]
+    while (queue.length) {
+      const id = queue.shift()!
+      if (!expandedNodes.has(id)) continue
+      for (const child of childMap.get(id) ?? []) {
+        if (!visible.has(child)) { visible.add(child); queue.push(child) }
+      }
+    }
+    return visible
+  }, [graph, expandedNodes, childMap])
+
+  const groupIndexMap = useMemo(() => {
+    if (!graph) return new Map<string, number>()
+    const groups = Array.from(new Set(graph.nodes.map((n) => n.group || 'general')))
+    return new Map(groups.map((g, i) => [g, i % GROUP_PALETTE.length]))
+  }, [graph])
+
+  const rawFlowNodes: Node[] = useMemo(() => {
+    if (!graph) return []
+    return graph.nodes
+      .filter((node) => visibleNodeIds.has(node.id))
+      .map((node) => {
+        const group = node.group || 'general'
+        const paletteIdx = group === 'root' ? 0 : group === 'main' ? 1 : (groupIndexMap.get(group) ?? 2)
+        const palette = GROUP_PALETTE[paletteIdx % GROUP_PALETTE.length]
+        const isRoot = node.id === 'root' || group === 'root'
+        const hasChildren = (childMap.get(node.id)?.length ?? 0) > 0
+        return {
+          id: node.id,
+          type: 'mindmap',
+          data: {
+            label: node.label,
+            palette,
+            isSelected: selectedNodeId === node.id,
+            isRoot,
+            hasChildren,
+            isExpanded: expandedNodes.has(node.id),
+            onToggle: handleToggle,
+          } satisfies MindMapNodeData,
+          sourcePosition: Position.Right,
+          targetPosition: Position.Left,
+          position: { x: 0, y: 0 },
+        }
+      })
+  }, [graph, visibleNodeIds, selectedNodeId, groupIndexMap, childMap, expandedNodes]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const flowEdges: Edge[] = useMemo(() => {
-    if (!mindMap) return []
-    return mindMap.graph.edges.map((edge, index) => ({
-      id: `${edge.source}-${edge.target}-${index}`,
-      source: edge.source,
-      target: edge.target,
-      label: edge.label,
-      type: 'smoothstep',
-      animated: false,
-      style: { stroke: '#7F8F78' },
-      labelStyle: { fontSize: 11, fill: '#4C5B51' },
-    }))
-  }, [mindMap])
+    if (!graph) return []
+    return graph.edges
+      .filter((e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target))
+      .map((edge, index) => ({
+        id: `${edge.source}-${edge.target}-${index}`,
+        source: edge.source,
+        target: edge.target,
+        type: 'smoothstep',
+        animated: false,
+        style: { stroke: '#4A6858', strokeWidth: 1.5 },
+      }))
+  }, [graph, visibleNodeIds])
 
-  const selectedNodeSource = selectedNodeId && mindMap ? mindMap.node_sources[selectedNodeId] : ''
-  const selectedNodeLabel = selectedNodeId && mindMap ? mindMap.graph.nodes.find((node) => node.id === selectedNodeId)?.label : ''
-  const canRegenerate = Boolean(mindMap) && !isGenerating && !isCurrentSelectionCached
+  const flowNodes = useMemo(
+    () => (rawFlowNodes.length ? applyDagreLayout(rawFlowNodes, flowEdges) : rawFlowNodes),
+    [rawFlowNodes, flowEdges],
+  )
+
+  const hasMindMap = Boolean(graph?.nodes.length)
 
   return (
     <div className="study-page">
       <section className="study-header">
         <h1>Concept Mind Map</h1>
-        <p>Generate a visual graph from interview documents for the selected job context.</p>
+        <p>Generate a visual knowledge graph, then chat with your documents.</p>
       </section>
 
+      {/* Controls */}
       <section className="card p-4 space-y-3">
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className="grid gap-3 md:grid-cols-2">
           <div>
-            <label className="label" htmlFor="mindmap-job-id">
-              Job id
-            </label>
-            <input
-              id="mindmap-job-id"
-              className="input"
-              value={jobIdInput}
-              onChange={(event) => setJobIdInput(event.target.value)}
-              placeholder="e.g. 42"
-            />
-          </div>
-          <div>
-            <label className="label" htmlFor="mindmap-doc-id">
-              Document scope
-            </label>
+            <label className="label" htmlFor="mindmap-doc-id">Document</label>
             <select
               id="mindmap-doc-id"
               className="input"
               value={selectedDocId ?? ''}
-              onChange={(event) => setSelectedDocId(event.target.value ? Number(event.target.value) : null)}
-              disabled={!jobId}
+              onChange={(e) => setSelectedDocId(e.target.value ? Number(e.target.value) : null)}
             >
-              <option value="">All job documents (top-k)</option>
+              <option value="">Select a document…</option>
               {documents.map((doc) => (
-                <option key={doc.id} value={doc.id}>
-                  {doc.source_filename} (#{doc.id})
-                </option>
+                <option key={doc.id} value={doc.id}>{doc.source_filename} (#{doc.id})</option>
               ))}
             </select>
           </div>
-          <div className="flex items-end gap-2">
-            <button type="button" className="btn-secondary w-full" onClick={applyJobId}>
-              Apply Job
-            </button>
-          </div>
         </div>
-
-        <div className="flex flex-wrap gap-2">
-          <button type="button" className="btn-primary inline-flex items-center gap-2" onClick={() => void handleGenerate()} disabled={isGenerating}>
-            {isGenerating ? <Loader2 className="spinner" /> : <Network className="w-4 h-4" />}
-            {mindMap ? 'Refresh Mind Map' : 'Generate Mind Map'}
-          </button>
+        <div className="flex flex-wrap gap-2 items-center">
           <button
             type="button"
-            className="btn-secondary inline-flex items-center gap-2"
-            onClick={() => void handleGenerate()}
-            disabled={!canRegenerate}
-            title={canRegenerate ? 'Document content changed. Regenerate available.' : 'Regeneration is available after content changes.'}
+            className="btn-primary inline-flex items-center gap-2"
+            onClick={() => { void handleGenerate() }}
+            disabled={!selectedDocId || isGenerating || status === 'generating'}
           >
-            <RefreshCcw className="w-4 h-4" />
-            Regenerate
+            {isGenerating || status === 'generating' ? <Loader2 className="spinner" /> : <Network className="w-4 h-4" />}
+            {hasMindMap ? 'Regenerate' : 'Generate Mind Map'}
           </button>
-          {mindMap ? (
+          {hasMindMap && (
             <span className="text-xs text-text-muted self-center">
-              {mindMap.graph.nodes.length} nodes, {mindMap.graph.edges.length} edges
+              {graph!.nodes.length} nodes · {graph!.edges.length} edges
             </span>
-          ) : null}
+          )}
         </div>
       </section>
 
       {error ? <p className="error">{error}</p> : null}
 
-      {status === 'loading' ? (
+      {status === 'generating' && (
         <section className="card p-4 flex items-center gap-2 text-sm text-text-secondary">
           <Loader2 className="spinner" />
-          Loading cached mind map...
+          Extracting concepts… nodes will appear as batches complete.
         </section>
-      ) : null}
+      )}
 
-      {!mindMap && status !== 'loading' ? (
+      {!hasMindMap && status !== 'generating' && (
         <section className="empty-state">
-          <h2>No cached map for this document state.</h2>
-          <p>Generate one now. If you update or re-upload documents, regenerate becomes available for the new content.</p>
+          <h2>{selectedDocId ? 'No cached map yet.' : 'Select a document to begin.'}</h2>
+          <p>Pick a document and click Generate. Click any node to chat about it.</p>
         </section>
-      ) : null}
+      )}
 
-      {mindMap ? (
-        <section className="grid gap-4 lg:grid-cols-[1fr_300px]">
-          <article className="card p-3" style={{ height: 560 }}>
+      {/* Map + chat layout */}
+      {hasMindMap && (
+        <section className="relative" style={{ height: 'calc(100vh - 240px)', minHeight: 600 }}>
+          {/* Full-width mind map */}
+          <article className="card p-0 overflow-hidden w-full h-full">
             <ReactFlow
               nodes={flowNodes}
               edges={flowEdges}
+              nodeTypes={NODE_TYPES}
               fitView
-              onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+              fitViewOptions={{ padding: 0.2 }}
+              onNodeClick={(event, node) => { void handleNodeClick(event, node) }}
               proOptions={{ hideAttribution: true }}
             >
-              <Background />
+              <Background color="#334" gap={24} />
               <Controls />
             </ReactFlow>
           </article>
-          <aside className="card p-4 space-y-3">
-            <h2 className="section-title">Source Chunk</h2>
-            {selectedNodeLabel ? <p className="text-sm font-medium text-text-primary">{selectedNodeLabel}</p> : null}
-            <p className="text-xs text-text-muted">
-              {selectedNodeSource || 'Click any node in the graph to inspect the supporting source chunk.'}
-            </p>
-          </aside>
+
+          {/* Floating chat toggle button */}
+          {taskId && !chatOpen && (
+            <button
+              type="button"
+              onClick={() => setChatOpen(true)}
+              className="absolute bottom-4 right-4 btn-primary flex items-center gap-2 shadow-lg z-10"
+            >
+              <Send className="w-4 h-4" />
+              Chat
+              {chatMessages.length > 0 && (
+                <span className="bg-white/20 rounded-full text-xs px-1.5">{chatMessages.length}</span>
+              )}
+            </button>
+          )}
+
+          {/* Slide-in chat panel */}
+          {chatOpen && (
+            <div
+              className="absolute top-0 right-0 h-full card rounded-l-xl rounded-r-none flex flex-col shadow-2xl z-10"
+              style={{ width: 360 }}
+            >
+              <div className="px-4 py-3 border-b border-border shrink-0 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-text-primary">Chat</p>
+                  <p className="text-xs text-text-muted">Ask anything about the document.</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setChatOpen(false)}
+                  className="text-text-muted hover:text-text-primary transition-colors text-lg leading-none"
+                >
+                  ×
+                </button>
+              </div>
+
+              <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4 min-h-0">
+                {chatMessages.length === 0 && (
+                  <p className="text-xs text-text-muted text-center pt-8">
+                    Click a node in the graph or ask a question below.
+                  </p>
+                )}
+                {chatMessages.map((msg, i) => <ChatBubble key={i} msg={msg} />)}
+                {isChatLoading && (
+                  <div className="flex items-center gap-2 text-sm text-text-secondary">
+                    <Loader2 className="spinner" /> Generating…
+                  </div>
+                )}
+                <div ref={chatEndRef} />
+              </div>
+
+              <div className="px-4 py-3 border-t border-border shrink-0">
+                <div className="flex gap-2">
+                  <input
+                    className="input flex-1 text-sm"
+                    placeholder="Ask about the document…"
+                    value={chatInput}
+                    disabled={isChatLoading}
+                    onChange={(e) => setChatInput(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void handleChatSubmit() } }}
+                  />
+                  <button
+                    type="button"
+                    className="btn-primary shrink-0 px-3"
+                    onClick={() => { void handleChatSubmit() }}
+                    disabled={!chatInput.trim() || isChatLoading}
+                  >
+                    <Send className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
         </section>
-      ) : null}
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/StudyMindMap.tsx
+++ b/frontend/src/pages/StudyMindMap.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useState } from 'react'
+import ReactFlow, { Background, Controls, type Edge, type Node, Position } from 'reactflow'
+import 'reactflow/dist/style.css'
+import { Loader2, Network, RefreshCcw } from 'lucide-react'
+import toast from 'react-hot-toast'
+
+import {
+  generateStudyMindMap,
+  getInterviewDocuments,
+  getJobInterviewDocuments,
+  getStudyMindMap,
+  type InterviewKnowledgeDocument,
+  type StudyMindMapResponse,
+} from '../lib/api'
+
+type MapStatus = 'idle' | 'loading' | 'ready'
+
+export default function StudyMindMap() {
+  const [jobIdInput, setJobIdInput] = useState('')
+  const [jobId, setJobId] = useState<number | null>(null)
+  const [documents, setDocuments] = useState<InterviewKnowledgeDocument[]>([])
+  const [selectedDocId, setSelectedDocId] = useState<number | null>(null)
+  const [mindMap, setMindMap] = useState<StudyMindMapResponse | null>(null)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [status, setStatus] = useState<MapStatus>('idle')
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [isCurrentSelectionCached, setIsCurrentSelectionCached] = useState(false)
+  const [error, setError] = useState('')
+
+  const extractErrorMessage = (errorValue: unknown): string => {
+    const typed = errorValue as { response?: { data?: { detail?: string } }; message?: string }
+    return typed?.response?.data?.detail || typed?.message || 'Request failed'
+  }
+
+  const loadSelection = async (nextJobId: number, nextDocId: number | null) => {
+    setStatus('loading')
+    setError('')
+    setMindMap(null)
+    setSelectedNodeId(null)
+    try {
+      const data = await getStudyMindMap(nextJobId, nextDocId)
+      setMindMap(data)
+      setIsCurrentSelectionCached(true)
+      setStatus('ready')
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err)
+      if (message.toLowerCase().includes('not found')) {
+        setIsCurrentSelectionCached(false)
+        setStatus('idle')
+        return
+      }
+      setError(message)
+      setStatus('idle')
+    }
+  }
+
+  const loadDocuments = async (nextJobId: number) => {
+    try {
+      const [globalDocs, jobDocs] = await Promise.all([
+        getInterviewDocuments(),
+        getJobInterviewDocuments(nextJobId),
+      ])
+      const seen = new Set<number>()
+      const merged = [...jobDocs, ...globalDocs].filter((doc) => {
+        if (seen.has(doc.id)) return false
+        seen.add(doc.id)
+        return true
+      })
+      setDocuments(merged)
+      if (selectedDocId && merged.every((doc) => doc.id !== selectedDocId)) {
+        setSelectedDocId(null)
+      }
+    } catch {
+      setDocuments([])
+    }
+  }
+
+  useEffect(() => {
+    if (!jobId) return
+    void loadDocuments(jobId)
+    void loadSelection(jobId, selectedDocId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobId, selectedDocId])
+
+  const applyJobId = () => {
+    const parsed = Number(jobIdInput)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      toast.error('Enter a valid job id.')
+      return
+    }
+    setJobId(parsed)
+  }
+
+  const handleGenerate = async () => {
+    if (!jobId) {
+      toast.error('Enter a job id first.')
+      return
+    }
+    setIsGenerating(true)
+    setError('')
+    try {
+      const payload = await generateStudyMindMap({ job_id: jobId, doc_id: selectedDocId ?? null })
+      setMindMap(payload)
+      setStatus('ready')
+      setIsCurrentSelectionCached(true)
+      setSelectedNodeId(payload.graph.nodes[0]?.id ?? null)
+      toast.success(payload.cached ? 'Loaded cached mind map.' : 'Mind map generated.')
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err)
+      setError(message)
+      toast.error(message)
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  const flowNodes: Node[] = useMemo(() => {
+    if (!mindMap) return []
+    const groups = Array.from(new Set(mindMap.graph.nodes.map((node) => node.group || 'general')))
+    const groupIndex = new Map(groups.map((group, index) => [group, index]))
+    return mindMap.graph.nodes.map((node, index) => {
+      const group = node.group || 'general'
+      const row = Math.floor(index / 4)
+      const col = index % 4
+      return {
+        id: node.id,
+        data: { label: node.label },
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+        position: {
+          x: col * 240 + (groupIndex.get(group) ?? 0) * 20,
+          y: row * 130 + (groupIndex.get(group) ?? 0) * 20,
+        },
+        style: {
+          borderRadius: 10,
+          border: '1px solid #A1B39A',
+          background: '#F4F9F2',
+          color: '#29342F',
+          fontSize: 12,
+          padding: 10,
+          width: 200,
+        },
+      }
+    })
+  }, [mindMap])
+
+  const flowEdges: Edge[] = useMemo(() => {
+    if (!mindMap) return []
+    return mindMap.graph.edges.map((edge, index) => ({
+      id: `${edge.source}-${edge.target}-${index}`,
+      source: edge.source,
+      target: edge.target,
+      label: edge.label,
+      type: 'smoothstep',
+      animated: false,
+      style: { stroke: '#7F8F78' },
+      labelStyle: { fontSize: 11, fill: '#4C5B51' },
+    }))
+  }, [mindMap])
+
+  const selectedNodeSource = selectedNodeId && mindMap ? mindMap.node_sources[selectedNodeId] : ''
+  const selectedNodeLabel = selectedNodeId && mindMap ? mindMap.graph.nodes.find((node) => node.id === selectedNodeId)?.label : ''
+  const canRegenerate = Boolean(mindMap) && !isGenerating && !isCurrentSelectionCached
+
+  return (
+    <div className="study-page">
+      <section className="study-header">
+        <h1>Concept Mind Map</h1>
+        <p>Generate a visual graph from interview documents for the selected job context.</p>
+      </section>
+
+      <section className="card p-4 space-y-3">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div>
+            <label className="label" htmlFor="mindmap-job-id">
+              Job id
+            </label>
+            <input
+              id="mindmap-job-id"
+              className="input"
+              value={jobIdInput}
+              onChange={(event) => setJobIdInput(event.target.value)}
+              placeholder="e.g. 42"
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="mindmap-doc-id">
+              Document scope
+            </label>
+            <select
+              id="mindmap-doc-id"
+              className="input"
+              value={selectedDocId ?? ''}
+              onChange={(event) => setSelectedDocId(event.target.value ? Number(event.target.value) : null)}
+              disabled={!jobId}
+            >
+              <option value="">All job documents (top-k)</option>
+              {documents.map((doc) => (
+                <option key={doc.id} value={doc.id}>
+                  {doc.source_filename} (#{doc.id})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-end gap-2">
+            <button type="button" className="btn-secondary w-full" onClick={applyJobId}>
+              Apply Job
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button type="button" className="btn-primary inline-flex items-center gap-2" onClick={() => void handleGenerate()} disabled={isGenerating}>
+            {isGenerating ? <Loader2 className="spinner" /> : <Network className="w-4 h-4" />}
+            {mindMap ? 'Refresh Mind Map' : 'Generate Mind Map'}
+          </button>
+          <button
+            type="button"
+            className="btn-secondary inline-flex items-center gap-2"
+            onClick={() => void handleGenerate()}
+            disabled={!canRegenerate}
+            title={canRegenerate ? 'Document content changed. Regenerate available.' : 'Regeneration is available after content changes.'}
+          >
+            <RefreshCcw className="w-4 h-4" />
+            Regenerate
+          </button>
+          {mindMap ? (
+            <span className="text-xs text-text-muted self-center">
+              {mindMap.graph.nodes.length} nodes, {mindMap.graph.edges.length} edges
+            </span>
+          ) : null}
+        </div>
+      </section>
+
+      {error ? <p className="error">{error}</p> : null}
+
+      {status === 'loading' ? (
+        <section className="card p-4 flex items-center gap-2 text-sm text-text-secondary">
+          <Loader2 className="spinner" />
+          Loading cached mind map...
+        </section>
+      ) : null}
+
+      {!mindMap && status !== 'loading' ? (
+        <section className="empty-state">
+          <h2>No cached map for this document state.</h2>
+          <p>Generate one now. If you update or re-upload documents, regenerate becomes available for the new content.</p>
+        </section>
+      ) : null}
+
+      {mindMap ? (
+        <section className="grid gap-4 lg:grid-cols-[1fr_300px]">
+          <article className="card p-3" style={{ height: 560 }}>
+            <ReactFlow
+              nodes={flowNodes}
+              edges={flowEdges}
+              fitView
+              onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background />
+              <Controls />
+            </ReactFlow>
+          </article>
+          <aside className="card p-4 space-y-3">
+            <h2 className="section-title">Source Chunk</h2>
+            {selectedNodeLabel ? <p className="text-sm font-medium text-text-primary">{selectedNodeLabel}</p> : null}
+            <p className="text-xs text-text-muted">
+              {selectedNodeSource || 'Click any node in the graph to inspect the supporting source chunk.'}
+            </p>
+          </aside>
+        </section>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add backend mind map extraction flow with `POST /study/mindmap` and `GET /study/mindmap`, including `MindMap` persistence keyed by `(job_id, doc_id, content_hash)` to avoid unnecessary regeneration.
- Add content-hash-aware cache behavior so stale maps are not returned after source document updates, plus service/router tests for generation, cache hit, and stale-cache miss.
- Add Study Hub mind map experience using `reactflow`, including graph rendering, node click source-chunk panel, and job/document scoped map generation controls.

## Verification
- `cd backend && pytest tests/test_study_router.py tests/test_study_service.py tests/test_mindmap_service.py`
- `cd frontend && npm run build`

## Notes
- Pragmatic assumption: for `doc_id = null`, top-k context uses the newest global/job documents and samples early chunks per document to keep generation bounded and deterministic.
- `Regenerate` is only available when current selection cache is stale/missing; initial generation is handled by `Generate Mind Map`.

Closes #28